### PR TITLE
Introduce a way to add protoc options to protobuf definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1243,7 +1243,7 @@ There are a few importing things to notice
 2. The value is an array. This is because Smithy will concatenate the arrays if the model contains multiple entries
 3. Each entry of the array is an object where the keys are the namespace and the values are objects that represent the options
 4. Entries for other namespaces are ignored (for example, `demo` in the example below)
-5. The object that represent an option can only use `String` as value (see the example below). More detail below.
+5. The object that represents an option can only use `String` as value (see the example below). More detail below.
 
 #### Stringly typed options
 

--- a/README.md
+++ b/README.md
@@ -1242,7 +1242,8 @@ There are a few importing things to notice
 1. All options are defined under the metadata key `proto_options`
 2. The value is an array. This is because Smithy will concatenate the arrays if the model contains multiple entries
 3. Each entry of the array is an object where the keys are the namespace and the values are objects that represent the options
-4. The object that represent an option can only use `String` as value (see the example below). More detail below.
+4. Entries for other namespaces are ignored (for example, `demo` in the example below)
+5. The object that represent an option can only use `String` as value (see the example below). More detail below.
 
 #### Stringly typed options
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ _Note: this library is published to work on Java 8 and above. However, you will 
       - [Enum](#enum-1)
     - [Service Shapes](#service-shapes-1)
       - [Basic Service](#basic-service-1)
+  - [Options](#options)
+    - [Stringly typed options](#stringly-typed-options)
+    - [Example](#example)
 
 ## Alloy
 
@@ -1227,5 +1230,57 @@ message Test200 {
 
 message TestInput {
   foo.InputBody body = 1;
+}
+```
+
+### Options
+
+Individual protobuf definitions file (`.proto`) can contain _options_. We support this feature using Smithy's metadata attribute. 
+
+There are a few importing things to notice
+
+1. All options are defined under the metadata key `proto_options`
+2. The value is an array. This is because Smithy will concatenate the arrays if the model contains multiple entries
+3. Each entry of the array is an object where the keys are the namespace and the values are objects that represent the options
+4. The object that represent an option can only use `String` as value (see the example below). More detail below.
+
+#### Stringly typed options
+
+We used a `String` to represent the option such as `"true"` for a boolean and `"\"demo\""` for a String because it's the simplest approach to cover all use cases supported by `protoc`. `protoc` supports simple types like you'd expect: `bool`, `int`, `float` and `string`. But it also supports `identifier` which are a reference to some value that `protoc` knows about. For example: `option optimize_for = CODE_SIZE;`. Using a `String` for the value allows us to model this, while keeping thing simple. It allows prevent the users from trying to use `Array`s or `Object` as value for options.
+
+#### Example
+
+The following is an example:
+
+Smithy:
+```kotlin
+$version: "2"
+
+metadata "proto_options" = [{
+  "foo": {
+      "java_multiple_files": "true",
+      "java_package": "\"foo.pkg\""
+  },
+  "demo": {
+      "java_multiple_files": "true"
+  }
+}]
+
+namespace foo
+
+string MyString
+```
+
+Proto:
+```proto
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "foo.pkg";
+
+package foo;
+
+message MyString {
+  string value = 1;
 }
 ```

--- a/modules/proto/core/src/smithyproto/proto3/MetadataProcessor.scala
+++ b/modules/proto/core/src/smithyproto/proto3/MetadataProcessor.scala
@@ -1,0 +1,72 @@
+/* Copyright 2022 Disney Streaming
+ *
+ * Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package smithyproto.proto3
+
+import software.amazon.smithy.model.Model
+import scala.jdk.OptionConverters._
+import scala.jdk.CollectionConverters._
+
+object MetadataProcessor {
+
+  type ProtocOptions = Map[String, Map[String, String]]
+
+  /* Example:
+   * ```
+   * metadata "proto_options" = [{
+   *   "demo": {
+   *       "java_multiple_files": "true",
+   *       "java_package": "\"demo.hello\""
+   *   }
+   * }]
+   * ```
+   */
+  def extractProtocOptions(m: Model): ProtocOptions = {
+    val protoOptionsNode =
+      Option(m.getMetadata().get("proto_options")).flatMap {
+        _.asArrayNode().toScala
+      }
+
+    protoOptionsNode match {
+      case None => Map.empty
+      case Some(protoOptions) =>
+        val listOfNamespaceNodes = protoOptions.asScala.toList
+          .flatMap(_.asObjectNode().toScala.toList)
+          .flatMap(_.getMembers().asScala)
+
+        listOfNamespaceNodes.foldLeft[ProtocOptions](Map.empty) {
+          case (acc, (nsNode, optionsNode)) =>
+            optionsNode.asObjectNode().toScala match {
+              case Some(options) =>
+                val nsOptions: Map[String, String] =
+                  options.getMembers().asScala.toMap.flatMap {
+                    case (optionKeyNode, optionValueNode) =>
+                      optionValueNode
+                        .asStringNode()
+                        .toScala
+                        .toList
+                        .map { strValue =>
+                          optionKeyNode.getValue() -> strValue.getValue()
+                        }
+                        .toMap
+                  }
+                acc + (nsNode.getValue -> nsOptions)
+              case None =>
+                acc
+            }
+        }
+    }
+  }
+}

--- a/modules/proto/core/src/smithyproto/proto3/ModelPreProcessor.scala
+++ b/modules/proto/core/src/smithyproto/proto3/ModelPreProcessor.scala
@@ -41,6 +41,7 @@ object ModelPreProcessor {
                 .filter(id => allowedNamespace.forall(_ == id.getNamespace()))
                 .toList,
               captureTraits = true,
+              captureMetadata = true,
               validateModel =
                 false // model may be in invalid state since it is in a transient/intermediary state of the proto conversion
             )

--- a/modules/proto/core/src/smithyproto/proto3/ProtoIR.scala
+++ b/modules/proto/core/src/smithyproto/proto3/ProtoIR.scala
@@ -19,13 +19,15 @@ object ProtoIR {
 
   final case class CompilationUnit(
       packageName: Option[String],
-      statements: List[Statement]
+      statements: List[Statement],
+      options: List[TopLevelOption]
   )
+
+  final case class TopLevelOption(key: String, value: String)
 
   sealed trait Statement
   object Statement {
     final case class ImportStatement(path: String) extends Statement
-    final case object OptionStatement extends Statement
     final case class TopLevelStatement(s: TopLevelDef) extends Statement
   }
 
@@ -189,5 +191,4 @@ object ProtoIR {
     def render: String =
       packageName.map(_.mkString(".")).map(_ + ".").getOrElse("") + name
   }
-
 }

--- a/modules/proto/core/src/smithyproto/proto3/Renderer.scala
+++ b/modules/proto/core/src/smithyproto/proto3/Renderer.scala
@@ -25,6 +25,10 @@ object Renderer {
     val text = many(
       statement(s"""syntax = "proto3""""),
       emptyLine,
+      many(
+        compilationUnit.options.map(renderOption) ++
+          compilationUnit.options.headOption.toList.map(_ => emptyLine)
+      ),
       maybe(
         compilationUnit.packageName.map(packageName =>
           many(renderPackageName(packageName), emptyLine)
@@ -43,10 +47,12 @@ object Renderer {
   def renderPackageName(packageName: String): Text =
     statement(s"package ${packageName}")
 
+  def renderOption(opt: TopLevelOption): Text =
+    statement(s"""option ${opt.key} = ${opt.value}""")
+
   def renderStatement(st: Statement): Text =
     st match {
       case Statement.ImportStatement(path)  => statement(s"""import "$path"""")
-      case Statement.OptionStatement        => Text.emptyLine
       case Statement.TopLevelStatement(tld) => renderTopLevelDef(tld)
     }
 

--- a/modules/proto/core/tests/src/CompilerRendererSuite.scala
+++ b/modules/proto/core/tests/src/CompilerRendererSuite.scala
@@ -691,6 +691,34 @@ class CompilerRendererSuite extends FunSuite {
     )
   }
 
+  test("proto options as metadata") {
+    val source = """|$version: "2"
+                    |
+                    |metadata "proto_options" = [{
+                    |  "another.namespace": {
+                    |    "java_multiple_files": "true",
+                    |    "java_package": "\"demo.hello\""
+                    |  }
+                    |}]
+                    |
+                    |namespace another.namespace
+                    |
+                    |string SomeString
+                    |""".stripMargin
+    val expected = """|syntax = "proto3";
+                      |
+                      |option java_multiple_files = true;
+                      |option java_package = "demo.hello";
+                      |
+                      |package another.namespace;
+                      |
+                      |message SomeString {
+                      |  string value = 1;
+                      |}
+                      |""".stripMargin
+    convertCheck(source, Map("another/namespace.proto" -> expected))
+  }
+
   /** Perform the same check as convertCheck but include the smithytranslate
     * namespace. To do so it prepends the proto api to your `expected` value.
     */

--- a/modules/proto/core/tests/src/CompilerSuite.scala
+++ b/modules/proto/core/tests/src/CompilerSuite.scala
@@ -62,7 +62,8 @@ class CompilerSuite extends FunSuite {
                 )
               )
             )
-          )
+          ),
+          List.empty
         )
       )
     )

--- a/modules/proto/core/tests/src/RendererSuite.scala
+++ b/modules/proto/core/tests/src/RendererSuite.scala
@@ -38,7 +38,8 @@ class RendererSuite extends FunSuite {
             )
           )
         )
-      )
+      ),
+      List.empty
     )
 
     val result = Renderer.render(unit)
@@ -131,7 +132,8 @@ class RendererSuite extends FunSuite {
             )
           )
         )
-      )
+      ),
+      List.empty
     )
 
     val result = Renderer.render(unit)
@@ -194,7 +196,8 @@ class RendererSuite extends FunSuite {
             )
           )
         )
-      )
+      ),
+      List.empty
     )
 
     val result = Renderer.render(unit)

--- a/modules/readme-validator/src/ReadmeParser.scala
+++ b/modules/readme-validator/src/ReadmeParser.scala
@@ -36,7 +36,7 @@ object ReadmeParser {
   private val tripleTick = string("```")
 
   private def header(title: String, language: String): Parser[Unit] =
-    (Parser.ignoreCase(title) ~ lf ~ tripleTick ~ string(language)).void
+    (Parser.ignoreCase(title) ~ lf ~ tripleTick ~ string(language) ~ lf).void
 
   private def part(
       header: Parser[Unit],

--- a/modules/transitive/src/closure/IdRefVisitor.scala
+++ b/modules/transitive/src/closure/IdRefVisitor.scala
@@ -95,6 +95,7 @@ final class IdRefVisitor(
               model,
               shapes.map(_.getId),
               captureTraits,
+              captureMetadata = false,
               validateModel
             )
             .toSet()

--- a/modules/transitive/src/closure/ModelOps.scala
+++ b/modules/transitive/src/closure/ModelOps.scala
@@ -52,9 +52,16 @@ object ModelOps {
     def transitiveClosure(
         shapeIds: List[ShapeId],
         captureTraits: Boolean = false,
+        captureMetadata: Boolean = false,
         validateModel: Boolean = true
     ): Model = {
-      TransitiveModel.compute(model, shapeIds, captureTraits, validateModel)
+      TransitiveModel.compute(
+        model,
+        shapeIds,
+        captureTraits,
+        captureMetadata,
+        validateModel
+      )
     }
   }
 }

--- a/modules/transitive/tests/src/ClosureSpec.scala
+++ b/modules/transitive/tests/src/ClosureSpec.scala
@@ -32,9 +32,19 @@ class ClosureSpec extends munit.FunSuite {
   test("when root shape id is passed in ,expect to retain entire model") {
     val model1 = inLineModel(sampleSpec)
     val result = model1
-      .transitiveClosure(List(ShapeId.from("example.weather#Weather")), true)
+      .transitiveClosure(
+        List(ShapeId.from("example.weather#Weather")),
+        captureTraits = true,
+        captureMetadata = true
+      )
       .check()
 
+    assertEquals(
+      result
+        .getMetadataProperty("some_key")
+        .flatMap(_.asStringNode().map(_.getValue)),
+      java.util.Optional.of("some value")
+    )
     assertEquals(result.prettyPrint, model1.prettyPrint)
   }
 

--- a/modules/transitive/tests/src/sample_specs.scala
+++ b/modules/transitive/tests/src/sample_specs.scala
@@ -15,7 +15,11 @@
 
 object sample_specs {
   val sampleSpec =
-    """namespace example.weather
+    """|$version: "2"
+      |
+      |metadata "some_key" = "some value"
+      |
+      |namespace example.weather
       |
       |/// Provides weather forecasts.
       |@paginated(inputToken: "nextToken", outputToken: "nextToken",


### PR DESCRIPTION
The MetadataProcessor takes a model and extract a per namespace map of options. Before rendering a namespace we retrieve the options for a namespace and add them to the CompilationUnit.

Encoded as follows:

1. we use smithy metadata proto_options
2. we use an array of objects so that multiple proto_options can be concatenated
3. the options are defined per namespace
4. the options are String -> String

Regarding 4), I chose this encoding over String -> Any(bool, string, float, integer, identifier) because of the identifier.

You can do `option thing = "that";` but you can also do: `option thing = THAT;` where THAT would be a constant that protoc knows about.

To workaround the issue, the value is always a string, so if you want the former, you do `"thing": "\"that\""`, and if you want the latter you do: `"thing": "THAT"`. As such, if you want a `bool` like `true`, you do `"thing": "true"`.

I'm open to revisit this if you have another proposition.