### PR TITLE
improves naming conversions for structure members

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ structure Testing {
 
 Required properties and nested structures are both supported.
 
-Any properties in the input structure that begin with a number will be prefixed by the letter `n`. This is because smithy does not allow for member names to begin with a number. You can change this is with post-processing if you want a different change to be made to names of this nature. Note that this extra `n` will not impact JSON encoding/decoding because we also attach the [JsonName Smithy trait](https://awslabs.github.io/smithy/2.0/spec/protocol-traits.html#jsonname-trait) to these properties. The same thing happens if the member name contains a hyphen. In this case, hyphens are replaced with underscores and a `jsonName` trait is once again added.
+Any properties in the input structure that begin with a number will be prefixed by the letter `n`. This is because smithy does not allow for member names to begin with a number. You can change this is with post-processing if you want a different change to be made to names of this nature. Note that this extra `n` will not impact JSON encoding/decoding because we also attach the [JsonName Smithy trait](https://awslabs.github.io/smithy/2.0/spec/protocol-traits.html#jsonname-trait) to these properties. The same thing happens if the member name contains a hyphen. In this case, hyphens are replaced with underscores and a `jsonName` trait is once again added. Note that if the field is a header, the `jsonName` annotation is not added since `httpHeader` is used instead.
 
 OpenAPI:
 ```yaml

--- a/README.md
+++ b/README.md
@@ -153,6 +153,8 @@ components:
       properties:
         myString:
           type: string
+        my_int:
+          type: integer
       required:
         - myString
 ```
@@ -162,10 +164,41 @@ Smithy:
 structure Testing {
  @required
  myString: String
+ my_int: Integer
 }
 ```
 
 Required properties and nested structures are both supported.
+
+Any properties in the input structure that begin with a number will be prefixed by the letter `n`. This is because smithy does not allow for member names to begin with a number. You can change this is with post-processing if you want a different change to be made to names of this nature. Note that this extra `n` will not impact JSON encoding/decoding because we also attach the [JsonName Smithy trait](https://awslabs.github.io/smithy/2.0/spec/protocol-traits.html#jsonname-trait) to these properties. The same thing happens if the member name contains a hyphen. In this case, hyphens are replaced with underscores and a `jsonName` trait is once again added.
+
+OpenAPI:
+```yaml
+openapi: '3.0.'
+info:
+  title: doc
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    Testing:
+      type: object
+      properties:
+        12_twelve:
+          type: string
+        X-something:
+          type: string
+```
+
+Smithy:
+```kotlin
+structure Testing {
+ @jsonName("12_twelve")
+ n12_twelve: String
+ @jsonName("X-something")
+ X_something: String
+}
+```
 
 ##### Untagged Union
 
@@ -698,7 +731,7 @@ operation TestOperationId {
 
 structure TestOperationIdInput {
     @httpHeader("X-username")
-    XUsername: String
+    X_username: String
 }
 
 structure Object {
@@ -712,7 +745,7 @@ structure TestOperationId200 {
     @contentType("application/json")
     body: Object,
     @httpHeader("X-RateLimit-Limit")
-    XRateLimitLimit: Integer
+    X_RateLimit_Limit: Integer
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ structure Testing {
 
 Required properties and nested structures are both supported.
 
-Any properties in the input structure that begin with a number will be prefixed by the letter `n`. This is because smithy does not allow for member names to begin with a number. You can change this is with post-processing if you want a different change to be made to names of this nature. Note that this extra `n` will not impact JSON encoding/decoding because we also attach the [JsonName Smithy trait](https://awslabs.github.io/smithy/2.0/spec/protocol-traits.html#jsonname-trait) to these properties. The same thing happens if the member name contains a hyphen. In this case, hyphens are replaced with underscores and a `jsonName` trait is once again added. Note that if the field is a header, the `jsonName` annotation is not added since `httpHeader` is used instead.
+Any properties in the input structure that begin with a number will be prefixed by the letter `n`. This is because smithy does not allow for member names to begin with a number. You can change this is with post-processing if you want a different change to be made to names of this nature. Note that this extra `n` will not impact JSON encoding/decoding because we also attach the [JsonName Smithy trait](https://awslabs.github.io/smithy/2.0/spec/protocol-traits.html#jsonname-trait) to these properties. The same thing happens if the member name contains a hyphen. In this case, hyphens are replaced with underscores and a `jsonName` trait is once again added. Note that if the field is a header or query parameter, the `jsonName` annotation is not added since `httpHeader` or `httpQuery` is used instead.
 
 OpenAPI:
 ```yaml

--- a/modules/json-schema/tests/src/StructureSpec.scala
+++ b/modules/json-schema/tests/src/StructureSpec.scala
@@ -77,4 +77,54 @@ final class StructureSpec extends munit.FunSuite {
 
     TestUtils.runConversionTest(jsonSchString, expectedString)
   }
+
+  test("structures - retain property member casing") {
+    val openapiString = """|{
+                           |  "$id": "test.json",
+                           |  "$schema": "http://json-schema.org/draft-07/schema#",
+                           |  "title": "Object",
+                           |  "type": "object",
+                           |  "properties": {
+                           |    "number_one": {
+                           |      "type": "string"
+                           |    },
+                           |    "numberTwo": {
+                           |      "type": "string"
+                           |    },
+                           |    "NumberThree": {
+                           |      "type": "string"
+                           |    },
+                           |    "NUMBER_FOUR": {
+                           |      "type": "string"
+                           |    },
+                           |    "nUMbeR_FiVE": {
+                           |      "type": "string"
+                           |    },
+                           |    "12_twelve": {
+                           |      "type": "string"
+                           |    },
+                           |    "X-something": {
+                           |      "type": "string"
+                           |    }
+                           |  }
+                           |}
+                           |""".stripMargin
+
+    val expectedString = """|namespace foo
+                            |
+                            |structure Object {
+                            | number_one: String
+                            | numberTwo: String
+                            | NumberThree: String
+                            | NUMBER_FOUR: String
+                            | nUMbeR_FiVE: String
+                            | @jsonName("12_twelve")
+                            | n12_twelve: String
+                            | @jsonName("X-something")
+                            | X_something: String
+                            |}
+                            |""".stripMargin
+
+    TestUtils.runConversionTest(openapiString, expectedString)
+  }
 }

--- a/modules/openapi/src/internals/Hint.scala
+++ b/modules/openapi/src/internals/Hint.scala
@@ -44,5 +44,6 @@ object Hint {
   case object Nullable extends Hint
   case class CurrentLocation(str: String) extends Hint
   case class TargetLocation(str: String) extends Hint
+  case class JsonName(name: String) extends Hint
 }
 // format: on

--- a/modules/openapi/src/internals/IModelToSmithy.scala
+++ b/modules/openapi/src/internals/IModelToSmithy.scala
@@ -39,6 +39,7 @@ import smithytranslate.NullableTrait
 import cats.syntax.all._
 import smithytranslate.NullFormatTrait
 import smithytranslate.openapi.internals.Hint.Header
+import smithytranslate.openapi.internals.Hint.QueryParam
 
 final class IModelToSmithy(useEnumTraitSyntax: Boolean)
     extends (IModel => Model) {
@@ -54,8 +55,12 @@ final class IModelToSmithy(useEnumTraitSyntax: Boolean)
             case Header(_) => true
             case _         => false
           }
+          val isQuery = hints.exists {
+            case QueryParam(_) => true
+            case _             => false
+          }
           val jsonNameHint =
-            if (!isHeader && nameWillNeedChange)
+            if (!isHeader && !isQuery && nameWillNeedChange)
               List(Hint.JsonName(memName))
             else List.empty
           MemberShape

--- a/modules/openapi/src/internals/IModelToSmithy.scala
+++ b/modules/openapi/src/internals/IModelToSmithy.scala
@@ -51,16 +51,13 @@ final class IModelToSmithy(useEnumTraitSyntax: Boolean)
           val memName = id.memberName.value.toString
           val nameWillNeedChange =
             memName.headOption.exists(_.isDigit) || memName.contains("-")
-          val isHeader = hints.exists {
-            case Header(_) => true
-            case _         => false
-          }
-          val isQuery = hints.exists {
+          def isHeaderOrQuery = hints.exists {
+            case Header(_)     => true
             case QueryParam(_) => true
             case _             => false
           }
           val jsonNameHint =
-            if (!isHeader && !isQuery && nameWillNeedChange)
+            if (nameWillNeedChange && !isHeaderOrQuery)
               List(Hint.JsonName(memName))
             else List.empty
           MemberShape

--- a/modules/openapi/src/internals/IModelToSmithy.scala
+++ b/modules/openapi/src/internals/IModelToSmithy.scala
@@ -236,8 +236,12 @@ final class IModelToSmithy(useEnumTraitSyntax: Boolean)
     StringUtil.toCamelCase(sanitizeForDigitStart(id))
   }
 
-  /** Used to replace things like `/path/{camel_case}/rest with
-    * `/path/{camelCase}/rest`. This ensures the memberName matches the uri
+  private def sanitizeMemberName(id: String): String = {
+    sanitizeForDigitStart(id).replaceAll("-", "_")
+  }
+
+  /** Used to replace things like `/path/{some-case}/rest with
+    * `/path/{some_case}/rest`. This ensures the memberName matches the uri
     * segment.
     */
   private def sanitizedUriPath(uriPath: String): String = {
@@ -249,7 +253,7 @@ final class IModelToSmithy(useEnumTraitSyntax: Boolean)
         .filter(_.trim.nonEmpty)
         .map { part =>
           if (part.startsWith("{") && part.endsWith("}")) {
-            val safe = sanitizeName(part.drop(1).dropRight(1))
+            val safe = sanitizeMemberName(part.drop(1).dropRight(1))
             s"{$safe}"
           } else {
             part

--- a/modules/openapi/tests/src/OperationHeaderSpec.scala
+++ b/modules/openapi/tests/src/OperationHeaderSpec.scala
@@ -70,7 +70,7 @@ final class OperationHeaderSpec extends munit.FunSuite {
                       |
                       |structure TestOperationIdInput {
                       |    @httpHeader("X-username")
-                      |    XUsername: String,
+                      |    X_username: String,
                       |}
                       |
                       |structure Object {
@@ -149,7 +149,7 @@ final class OperationHeaderSpec extends munit.FunSuite {
                       |    @contentType("application/json")
                       |    body: Object,
                       |    @httpHeader("X-RateLimit-Limit")
-                      |    XRateLimitLimit: Integer,
+                      |    X_RateLimit_Limit: Integer,
                       |}
                       |""".stripMargin
 
@@ -216,7 +216,7 @@ final class OperationHeaderSpec extends munit.FunSuite {
                       |
                       |structure TestOperationIdInput {
                       |    @httpHeader("X-username")
-                      |    XUsername: String,
+                      |    X_username: String,
                       |    @httpPayload
                       |    @documentation("Optional description in *Markdown*")
                       |    @contentType("application/json")
@@ -303,7 +303,7 @@ final class OperationHeaderSpec extends munit.FunSuite {
                       |    @contentType("application/json")
                       |    body: Object,
                       |    @httpHeader("X-Test-Header")
-                      |    XTestHeader: Integer
+                      |    X_Test_Header: Integer
                       |}
                       |""".stripMargin
 
@@ -378,7 +378,7 @@ final class OperationHeaderSpec extends munit.FunSuite {
                     |    @contentType("application/json")
                     |    body: Body,
                     |    @httpHeader("X-Test-Header")
-                    |    XTestHeader: Integer,
+                    |    X_Test_Header: Integer,
                     |}
                     |
                     |structure Body {

--- a/modules/openapi/tests/src/OperationSpec.scala
+++ b/modules/openapi/tests/src/OperationSpec.scala
@@ -733,9 +733,9 @@ final class OperationSpec extends munit.FunSuite {
                             |
                             |structure TestOperationInput {
                             |    @httpHeader("X-Request-Id")
-                            |    XRequestId: String,
+                            |    X_Request_Id: String,
                             |    @httpHeader("X-Forwarded-For")
-                            |    XForwardedFor: String,
+                            |    X_Forwarded_For: String,
                             |    @httpPayload
                             |    @required
                             |    @contentType("application/json")

--- a/modules/openapi/tests/src/OperationSpec.scala
+++ b/modules/openapi/tests/src/OperationSpec.scala
@@ -315,7 +315,7 @@ final class OperationSpec extends munit.FunSuite {
     TestUtils.runConversionTest(openapiString, expectedString)
   }
 
-  test("operation - query") {
+  test("operation - query".only) {
     val openapiString = """|openapi: '3.0.'
                      |info:
                      |  title: test
@@ -327,6 +327,18 @@ final class OperationSpec extends munit.FunSuite {
                      |      parameters:
                      |        - in: query
                      |          name: userId
+                     |          schema:
+                     |            type: integer
+                     |        - in: query
+                     |          name: some_id
+                     |          schema:
+                     |            type: integer
+                     |        - in: query
+                     |          name: other-id
+                     |          schema:
+                     |            type: integer
+                     |        - in: query
+                     |          name: 12-twelve
                      |          schema:
                      |            type: integer
                      |      responses:
@@ -369,6 +381,12 @@ final class OperationSpec extends munit.FunSuite {
                       |structure TestOperationIdInput {
                       |    @httpQuery("userId")
                       |    userId: Integer,
+                      |    @httpQuery("some_id")
+                      |    some_id: Integer,
+                      |    @httpQuery("other-id")
+                      |    other_id: Integer
+                      |    @httpQuery("12-twelve")
+                      |    n12_twelve: Integer
                       |}
                       |
                       |structure Object {

--- a/modules/openapi/tests/src/OperationSpec.scala
+++ b/modules/openapi/tests/src/OperationSpec.scala
@@ -315,7 +315,7 @@ final class OperationSpec extends munit.FunSuite {
     TestUtils.runConversionTest(openapiString, expectedString)
   }
 
-  test("operation - query".only) {
+  test("operation - query") {
     val openapiString = """|openapi: '3.0.'
                      |info:
                      |  title: test

--- a/modules/openapi/tests/src/ParameterSpec.scala
+++ b/modules/openapi/tests/src/ParameterSpec.scala
@@ -115,7 +115,7 @@ final class ParameterSpec extends munit.FunSuite {
                             |structure GenerateActivationTokenInput {
                             |    @httpHeader("X-Header-Test")
                             |    @required
-                            |    XHeaderTest: String,
+                            |    X_Header_Test: String,
                             |}""".stripMargin
 
     TestUtils.runConversionTest(openapiString, expectedString)
@@ -152,7 +152,7 @@ final class ParameterSpec extends munit.FunSuite {
                             |
                             |@http(
                             |    method: "GET",
-                            |    uri: "/content-providers/{contentProvider}/activation-token",
+                            |    uri: "/content-providers/{content_provider}/activation-token",
                             |    code: 200,
                             |)
                             |operation GenerateActivationToken {
@@ -163,7 +163,7 @@ final class ParameterSpec extends munit.FunSuite {
                             |structure GenerateActivationTokenInput {
                             |    @httpLabel
                             |    @required
-                            |    contentProvider: String,
+                            |    content_provider: String,
                             |}""".stripMargin
 
     TestUtils.runConversionTest(openapiString, expectedString)

--- a/modules/openapi/tests/src/StructureSpec.scala
+++ b/modules/openapi/tests/src/StructureSpec.scala
@@ -339,4 +339,49 @@ final class StructureSpec extends munit.FunSuite {
     TestUtils.runConversionTest(openapiString, expectedString)
   }
 
+  test("structures - retain property member casing") {
+    val openapiString = """|openapi: '3.0.'
+                           |info:
+                           |  title: test
+                           |  version: '1.0'
+                           |paths: {}
+                           |components:
+                           |  schemas:
+                           |    Object:
+                           |      type: object
+                           |      properties:
+                           |        number_one:
+                           |          type: string
+                           |        numberTwo:
+                           |          type: string
+                           |        NumberThree:
+                           |          type: string
+                           |        NUMBER_FOUR:
+                           |          type: string
+                           |        nUMbeR_FiVE:
+                           |          type: string
+                           |        12_twelve:
+                           |          type: string
+                           |        X-something:
+                           |          type: string
+                           |""".stripMargin
+
+    val expectedString = """|namespace foo
+                            |
+                            |structure Object {
+                            | number_one: String
+                            | numberTwo: String
+                            | NumberThree: String
+                            | NUMBER_FOUR: String
+                            | nUMbeR_FiVE: String
+                            | @jsonName("12_twelve")
+                            | n12_twelve: String
+                            | @jsonName("X-something")
+                            | X_something: String
+                            |}
+                            |""".stripMargin
+
+    TestUtils.runConversionTest(openapiString, expectedString)
+  }
+
 }


### PR DESCRIPTION
Preserves name for structure members wherever possible. Where not possible, it will add a jsonName annotation.
