### PR TITLE
Render union within message if used only once

### DIFF
--- a/README.md
+++ b/README.md
@@ -1123,6 +1123,11 @@ message Testing {
 
 Smithy:
 ```kotlin
+structure Union {
+  @required
+  value: TestUnion
+}
+
 union TestUnion {
     num: Integer,
     txt: String
@@ -1131,8 +1136,8 @@ union TestUnion {
 
 Proto:
 ```proto
-message TestUnion {
-  oneof TestUnionOneof {
+message Union {
+  oneof value {
     int32 num = 1;
     string txt = 2;
   }

--- a/build.sc
+++ b/build.sc
@@ -302,7 +302,7 @@ object transitive extends BaseScalaModule {
 
 object Deps {
   object alloy {
-    val core = ivy"com.disneystreaming.alloy:alloy-core:0.1.1"
+    val core = ivy"com.disneystreaming.alloy:alloy-core:0.1.2"
   }
   object circe {
     val jawn = ivy"io.circe::circe-jawn:0.14.3"

--- a/modules/proto/core/src/smithyproto/proto3/Compiler.scala
+++ b/modules/proto/core/src/smithyproto/proto3/Compiler.scala
@@ -61,11 +61,10 @@ class Compiler() {
       excludeInternal(s) || Prelude.isPreludeShape(s)
   }
 
-  /** Union shape can be used zero time, in which case they're exported in a top
-    * level message with one `value` member of type `oneOf`.
+  /** Unused union shape are not exported.
     *
-    * They can be used one time, in which case they're exported within the
-    * structure that uses them.
+    * Union shapes used exactly once are exported within the structure that uses
+    * them.
     *
     * If they're used more than once, this function will throw.
     */

--- a/modules/proto/core/tests/src/CompilerRendererSuite.scala
+++ b/modules/proto/core/tests/src/CompilerRendererSuite.scala
@@ -21,17 +21,7 @@ import smithyproto.validation.ProtoValidator
 
 class CompilerRendererSuite extends FunSuite {
 
-  test("top level - union") {
-    val expected = """|syntax = "proto3";
-                      |
-                      |package com.example;
-                      |
-                      |message MyUnion {
-                      |  oneof MyUnionOneof {
-                      |    string name = 1;
-                      |    int32 id = 2;
-                      |  }
-                      |}""".stripMargin
+  test("top level - union (not used within a structure) are not exported") {
     val source = """|namespace com.example
                     |
                     |union MyUnion {
@@ -39,7 +29,63 @@ class CompilerRendererSuite extends FunSuite {
                     |  id: Integer
                     |}
                     |""".stripMargin
+    convertCheck(source, Map.empty)
+  }
+
+  test("top level - union (used within only one data structure)") {
+    val source = """|namespace com.example
+                    |
+                    |structure WithUnion {
+                    |  @required
+                    |  age: Integer
+                    |  @required
+                    |  myUnion: MyUnion
+                    |  @required
+                    |  other: String
+                    |}
+                    |
+                    |union MyUnion {
+                    |  name: String,
+                    |  id: Integer
+                    |}
+                    |""".stripMargin
+
+    val expected = """|syntax = "proto3";
+                      |
+                      |package com.example;
+                      |
+                      |message WithUnion {
+                      |  int32 age = 1;
+                      |  oneof myUnion {
+                      |    string name = 2;
+                      |    int32 id = 3;
+                      |  }
+                      |  string other = 4;
+                      |}
+                      |""".stripMargin
     convertCheck(source, Map("com/example.proto" -> expected))
+  }
+
+  test("top level - union (used within multiple data structures)") {
+    val source = """|namespace com.example
+                    |
+                    |structure WithUnion {
+                    |  @required
+                    |  myUnion: MyUnion
+                    |}
+                    |
+                    |list OfUnion {
+                    |  member: MyUnion
+                    |}
+                    |
+                    |union MyUnion {
+                    |  name: String,
+                    |  id: Integer
+                    |}
+                    |""".stripMargin
+    intercept[RuntimeException](
+      convertCheck(source, Map.empty)
+    )
   }
 
   test("top level - document") {
@@ -570,6 +616,45 @@ class CompilerRendererSuite extends FunSuite {
                    |  repeated com.example.ListItem strings = 1;
                    |}
                    |""".stripMargin
+    convertCheck(source, Map("com/example.proto" -> expected))
+  }
+
+  test("inline list with a union") {
+    val source = """|namespace com.example
+                    |
+                    |union MyUnion {
+                    |  name: String,
+                    |  id: Integer
+                    |}
+                    |
+                    |structure UnionStruct {
+                    |  @required
+                    |  value: MyUnion
+                    |}
+                    |
+                    |list ListOfUnion {
+                    |  member: UnionStruct
+                    |}
+                    |
+                    |structure Unions {
+                    |  @required
+                    |  values: ListOfUnion
+                    |}
+                    |""".stripMargin
+    val expected = """|syntax = "proto3";
+                      |
+                      |package com.example;
+                      |
+                      |message UnionStruct {
+                      |  oneof value {
+                      |    string name = 1;
+                      |    int32 id = 2;
+                      |  }
+                      |}
+                      |
+                      |message Unions {
+                      |  repeated com.example.UnionStruct values = 1;
+                      |}""".stripMargin
     convertCheck(source, Map("com/example.proto" -> expected))
   }
 

--- a/modules/proto/examples/README.md
+++ b/modules/proto/examples/README.md
@@ -3,7 +3,7 @@
 ## cli
 
 ```
-mill proto.cli.run --namespaces demo -i modules/proto/examples/smithy/demo.smithy modules/proto/examples/protobuf/
+mill cli.run smithy-to-proto -i modules/proto/examples/smithy/demo.smithy modules/proto/examples/protobuf/
 ```
 
 ## shell

--- a/modules/proto/examples/protobuf/demo/definitions.proto
+++ b/modules/proto/examples/protobuf/demo/definitions.proto
@@ -30,6 +30,11 @@ message HelloResponse {
   string message = 1;
   google.protobuf.UInt64Value size = 2;
   demo.UseApiStruct apiStruct = 3;
+  oneof apiUnion {
+    string version = 4;
+    int32 id = 5;
+  }
+  int64 anotherLong = 6;
 }
 
 message UseApiStruct {

--- a/modules/proto/examples/smithy/demo.smithy
+++ b/modules/proto/examples/smithy/demo.smithy
@@ -58,10 +58,24 @@ structure HelloResponse {
 
     @protoIndex(3)
     apiStruct: UseApiStruct
+
+    @required
+    apiUnion: ApiUnion
+
+    @protoIndex(6)
+    @required
+    anotherLong: Long,
 }
 
 structure UseApiStruct {
   bigInt: BigInteger,
   bigDec: BigDecimal,
   ts: Timestamp
+}
+
+union ApiUnion {
+  @protoIndex(4)
+  version: String,
+  @protoIndex(5)
+  id: Integer
 }

--- a/smithy-build.json
+++ b/smithy-build.json
@@ -1,4 +1,6 @@
 {
   "imports": ["./modules/proto/examples/smithy"],
-  "mavenDependencies": ["com.disneystreaming.alloy:alloy-core:0.1.0"]
+  "maven": {
+    "dependencies": ["com.disneystreaming.alloy:alloy-core:0.1.2"]
+  }
 }


### PR DESCRIPTION
If used more than once, throw
If unused, the shape is not exported
