### PR TITLE
JsonSchema: fix string type enums

### DIFF
--- a/modules/json-schema/src/internals/Extractors.scala
+++ b/modules/json-schema/src/internals/Extractors.scala
@@ -27,7 +27,6 @@ import smithytranslate.openapi.internals.Hint
 import smithytranslate.openapi.internals.GetExtensions
 import scala.jdk.CollectionConverters._
 import cats.syntax.all._
-import scala.collection.immutable.VectorImpl
 
 object Extractors {
 

--- a/modules/json-schema/src/internals/Extractors.scala
+++ b/modules/json-schema/src/internals/Extractors.scala
@@ -27,6 +27,7 @@ import smithytranslate.openapi.internals.Hint
 import smithytranslate.openapi.internals.GetExtensions
 import scala.jdk.CollectionConverters._
 import cats.syntax.all._
+import scala.collection.immutable.VectorImpl
 
 object Extractors {
 
@@ -41,12 +42,33 @@ object Extractors {
   }
 
   object CaseEnum {
+
+    // returns the EnumSchema if the only two schemas in the vector are an
+    // enum and a string type. This indicates that it is an enum of type
+    // string.
+    private def onlyEnumAndStringType(v: Vector[Schema]): Option[EnumSchema] = {
+      v.toList match {
+        case (first: EnumSchema) :: (_: StringSchema) :: Nil  => Some(first)
+        case (_: StringSchema) :: (second: EnumSchema) :: Nil => Some(second)
+        case _                                                => None
+      }
+    }
+
+    private def getValues(e: EnumSchema): Vector[String] = {
+      e.getPossibleValues.asScala.collect { case s: String =>
+        s
+      }.toVector
+    }
+
     def unapply(sch: Schema): Option[(List[Hint], Vector[String])] = sch match {
       case e: EnumSchema =>
-        val enumValues = e.getPossibleValues.asScala.collect { case s: String =>
-          s
-        }.toVector
+        val enumValues = getValues(e)
         Some(getGenericHints(sch) -> enumValues)
+      case CaseAllOf(_, schemas) =>
+        onlyEnumAndStringType(schemas) match {
+          case None    => None
+          case Some(e) => Some(getGenericHints(sch) -> getValues(e))
+        }
       case _ => None
     }
   }

--- a/modules/json-schema/tests/src/EnumSpec.scala
+++ b/modules/json-schema/tests/src/EnumSpec.scala
@@ -60,4 +60,46 @@ final class EnumSpec extends munit.FunSuite {
     )
   }
 
+  test("enums - string type") {
+    val jsonSchString = """|{
+                           |  "$id": "test.json",
+                           |  "$schema": "http://json-schema.org/draft-07/schema#",
+                           |  "title": "TestIt",
+                           |  "type": "object",
+                           |  "properties": {
+                           |    "someValue": {
+                           |      "type": "string",
+                           |      "enum": ["ONE", "TWO", "THREE"]
+                           |    }
+                           |  }
+                           |}
+                           |""".stripMargin
+
+    val expectedString = """|namespace foo
+                            |
+                            |@enum([
+                            |    {
+                            |        value: "ONE"
+                            |    },
+                            |    {
+                            |        value: "TWO"
+                            |    },
+                            |    {
+                            |        value: "THREE"
+                            |    }
+                            |])
+                            |string SomeValue
+                            |
+                            |structure TestIt {
+                            | someValue: SomeValue
+                            |}
+                            |""".stripMargin
+
+    TestUtils.runConversionTest(
+      jsonSchString,
+      expectedString,
+      smithyVersion = SmithyVersion.One
+    )
+  }
+
 }


### PR DESCRIPTION
Fixes an issue where JsonSchema enums with a type string field were being converted incorrectly.