### PR TITLE
convert object with additional  properties to smithy map

### DIFF
--- a/modules/json-schema/src/internals/Extractors.scala
+++ b/modules/json-schema/src/internals/Extractors.scala
@@ -183,6 +183,12 @@ object Extractors {
         val genericHints = getGenericHints(sch)
         Option(obj.getPatternProperties().asScala.head._2)
           .map(genericHints -> _)
+      case (obj: ObjectSchema)
+          if obj.getPropertySchemas().size() == 0 && obj
+            .getSchemaOfAdditionalProperties() != null =>
+        val genericHints = getGenericHints(sch)
+        Option(obj.getSchemaOfAdditionalProperties())
+          .map(genericHints -> _)
       case _ => None
     }
   }

--- a/modules/json-schema/src/internals/Extractors.scala
+++ b/modules/json-schema/src/internals/Extractors.scala
@@ -187,8 +187,7 @@ object Extractors {
           if obj.getPropertySchemas().size() == 0 && obj
             .getSchemaOfAdditionalProperties() != null =>
         val genericHints = getGenericHints(sch)
-        Option(obj.getSchemaOfAdditionalProperties())
-          .map(genericHints -> _)
+        Some(genericHints -> obj.getSchemaOfAdditionalProperties())
       case _ => None
     }
   }

--- a/modules/json-schema/tests/src/MapSpec.scala
+++ b/modules/json-schema/tests/src/MapSpec.scala
@@ -41,4 +41,27 @@ final class MapSpec extends munit.FunSuite {
 
     TestUtils.runConversionTest(jsonSchString, expectedString)
   }
+
+  test("additionalProperties") {
+    val jsonSchString = """|{
+                           |  "$id": "test.json",
+                           |  "$schema": "http://json-schema.org/draft-07/schema#",
+                           |  "title": "TestMap",
+                           |  "type": "object",
+                           |  "additionalProperties": {
+                           |    "type": "string"
+                           |  }
+                           |}
+                           |""".stripMargin
+
+    val expectedString = """|namespace foo
+                            |
+                            |map TestMap {
+                            | key: String,
+                            | value: String
+                            |}
+                            |""".stripMargin
+
+    TestUtils.runConversionTest(jsonSchString, expectedString)
+  }
 }


### PR DESCRIPTION
A json schema definition of an object with no explicit property but with `additionalProperties` set should convert to a smithy `map` definition.

With this change, the following definition
```json
{
  "title": "foo",
  "properties": {
    "shouldBeAMap": {
      "type": "object",
      "additionalProperties": {
        "type": "string"
      }
    }
  }
}
```
will convert to
```smithy
structure Foo {
    shouldBeAMap: ShouldBeAMap
}

structure ShouldBeAMap {
  key: String
  value: String
}
```