### PR TITLE
Add a debug flag

### DIFF
--- a/modules/cli/src/opts/OpenAPIJsonSchemaOpts.scala
+++ b/modules/cli/src/opts/OpenAPIJsonSchemaOpts.scala
@@ -26,7 +26,8 @@ final case class OpenAPIJsonSchemaOpts(
     useVerboseNames: Boolean,
     failOnValidationErrors: Boolean,
     useEnumTraitSyntax: Boolean,
-    outputJson: Boolean
+    outputJson: Boolean,
+    debug: Boolean
 )
 
 object OpenAPIJsonSchemaOpts {
@@ -58,6 +59,13 @@ object OpenAPIJsonSchemaOpts {
     )
     .orFalse
 
+  private val debug = Opts
+    .flag(
+      "debug",
+      "print more information as when processing the inputes"
+    )
+    .orFalse
+
   private def getOpts(isOpenapi: Boolean) =
     (
       CommonOpts.sources,
@@ -65,9 +73,10 @@ object OpenAPIJsonSchemaOpts {
       verboseNames,
       failOnValidationErrors,
       useEnumTraitSyntax,
-      outputJson
+      outputJson,
+      debug
     ).mapN(
-      OpenAPIJsonSchemaOpts.apply(isOpenapi, _, _, _, _, _, _)
+      OpenAPIJsonSchemaOpts.apply(isOpenapi, _, _, _, _, _, _, _)
     )
 
   private val openApiToSmithyCmd = Command(

--- a/modules/cli/src/runners/OpenApi.scala
+++ b/modules/cli/src/runners/OpenApi.scala
@@ -34,7 +34,8 @@ object OpenApi {
         transformers,
         opts.useEnumTraitSyntax,
         opts.debug
-      )
+      ),
+      opts.debug
     )
   }
 
@@ -50,7 +51,8 @@ object OpenApi {
         transformers,
         opts.useEnumTraitSyntax,
         opts.debug
-      )
+      ),
+      opts.debug
     )
   }
 }

--- a/modules/cli/src/runners/OpenApi.scala
+++ b/modules/cli/src/runners/OpenApi.scala
@@ -32,7 +32,8 @@ object OpenApi {
         useVerboseNames = opts.useVerboseNames,
         failOnValidationErrors = opts.failOnValidationErrors,
         transformers,
-        opts.useEnumTraitSyntax
+        opts.useEnumTraitSyntax,
+        opts.debug
       )
     )
   }
@@ -47,7 +48,8 @@ object OpenApi {
         useVerboseNames = opts.useVerboseNames,
         failOnValidationErrors = opts.failOnValidationErrors,
         transformers,
-        opts.useEnumTraitSyntax
+        opts.useEnumTraitSyntax,
+        opts.debug
       )
     )
   }

--- a/modules/cli/src/runners/openapi/ParseAndCompile.scala
+++ b/modules/cli/src/runners/openapi/ParseAndCompile.scala
@@ -27,7 +27,8 @@ object ParseAndCompile {
       useVerboseNames: Boolean,
       failOnValidationErrors: Boolean,
       transformers: List[TranslateTransformer],
-      useEnumTraitSyntax: Boolean
+      useEnumTraitSyntax: Boolean,
+      debug: Boolean
   ): OpenApiCompiler.Result[Model] = {
     val includedExtensions = List("yaml", "yml", "json")
     val inputs = getInputs(inputPaths, includedExtensions)
@@ -35,7 +36,8 @@ object ParseAndCompile {
       useVerboseNames,
       failOnValidationErrors,
       transformers,
-      useEnumTraitSyntax
+      useEnumTraitSyntax,
+      debug
     )
     OpenApiCompiler.parseAndCompile(opts, inputs: _*)
   }
@@ -45,7 +47,8 @@ object ParseAndCompile {
       useVerboseNames: Boolean,
       failOnValidationErrors: Boolean,
       transformers: List[TranslateTransformer],
-      useEnumTraitSyntax: Boolean
+      useEnumTraitSyntax: Boolean,
+      debug: Boolean
   ): OpenApiCompiler.Result[Model] = {
     val includedExtensions = List("json")
     val inputs = getInputs(inputPaths, includedExtensions)
@@ -53,7 +56,8 @@ object ParseAndCompile {
       useVerboseNames,
       failOnValidationErrors,
       transformers,
-      useEnumTraitSyntax
+      useEnumTraitSyntax,
+      debug
     )
     JsonSchemaCompiler.parseAndCompile(opts, inputs: _*)
   }

--- a/modules/cli/src/runners/openapi/ReportResult.scala
+++ b/modules/cli/src/runners/openapi/ReportResult.scala
@@ -75,7 +75,7 @@ final case class ReportResult(outputPath: os.Path, outputJson: Boolean) {
         path -> in._2
       }
 
-  def apply(result: OpenApiCompiler.Result[Model]): Unit = {
+  def apply(result: OpenApiCompiler.Result[Model], debug: Boolean): Unit = {
     result match {
       case OpenApiCompiler.Failure(error, modelErrors) =>
         val message = if (modelErrors.isEmpty) {
@@ -87,7 +87,11 @@ final case class ReportResult(outputPath: os.Path, outputJson: Boolean) {
               |$errorsSummary""".stripMargin
         }
         System.err.println(message)
-        error.printStackTrace(System.err)
+        if (debug) {
+          error.printStackTrace(System.err)
+        } else {
+          System.err.println(error.getMessage())
+        }
       case OpenApiCompiler.Success(modelErrors, model) =>
         modelErrors.foreach(e => System.err.println(e.getMessage()))
         val smithyFiles =

--- a/modules/cli/src/runners/openapi/ReportResult.scala
+++ b/modules/cli/src/runners/openapi/ReportResult.scala
@@ -78,11 +78,14 @@ final case class ReportResult(outputPath: os.Path, outputJson: Boolean) {
   def apply(result: OpenApiCompiler.Result[Model]): Unit = {
     result match {
       case OpenApiCompiler.Failure(error, modelErrors) =>
-        val errorsSummary = modelErrors.map(_.getMessage).mkString("\n")
-        val message =
+        val message = if (modelErrors.isEmpty) {
+          "An error occurred while importing your Open API resources."
+        } else {
+          val errorsSummary = modelErrors.map(_.getMessage).mkString("\n")
           s"""|Failed to validate the produced Smithy model. The following is a list of
-                          |error messages followed by the validation exception from Smithy:
-                          |$errorsSummary""".stripMargin
+              |error messages followed by the validation exception from Smithy:
+              |$errorsSummary""".stripMargin
+        }
         System.err.println(message)
         error.printStackTrace(System.err)
       case OpenApiCompiler.Success(modelErrors, model) =>

--- a/modules/json-schema/src/JsonSchemaCompiler.scala
+++ b/modules/json-schema/src/JsonSchemaCompiler.scala
@@ -28,6 +28,7 @@ import org.json.JSONObject
 import smithytranslate.openapi.OpenApiCompiler._
 import io.circe.Json
 import smithytranslate.json_schema.internals.LoadSchema
+import software.amazon.smithy.model.validation.ValidatedResultException
 
 /** Converts json schema to a smithy model.
   */
@@ -78,6 +79,7 @@ object JsonSchemaCompiler {
     scala.util
       .Try(validate(smithy0))
       .toEither
+      .leftMap(opts.debugModelValidationError)
       .map(transform(opts))
       .fold(
         err => Failure(err, errors),

--- a/modules/json-schema/tests/src/TestUtils.scala
+++ b/modules/json-schema/tests/src/TestUtils.scala
@@ -54,7 +54,8 @@ object TestUtils {
           useVerboseNames = false,
           failOnValidationErrors = false,
           List.empty,
-          input0.smithyVersion == SmithyVersion.One
+          input0.smithyVersion == SmithyVersion.One,
+          debug = true
         ),
         inputs.map(i => i.filePath -> i.jsonSpec): _*
       )

--- a/modules/openapi/tests/resources/issue-23.json
+++ b/modules/openapi/tests/resources/issue-23.json
@@ -1,0 +1,102 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Testers Service v1",
+    "description": "",
+    "contact": {
+      "name": "",
+      "url": ""
+    },
+    "version": "1.0"
+  },
+  "servers": [
+    {
+      "url": ""
+    }
+  ],
+  "paths": {
+    "/Testers/{id}": {
+      "get": {
+        "tags": ["Testers"],
+        "summary": "Testers_GetTest",
+        "operationId": "Testers_GetTest",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Format - uuid.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Testers.DataContracts.Responses.Command.GetTestByIdCommandResponse"
+                },
+                "example": {
+                  "Test": {}
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/Testers/queries/unique-tags": {
+      "get": {
+        "tags": ["Testers"],
+        "summary": "Testers_GetTestTags",
+        "operationId": "Testers_GetTestTags",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Testers.DataContracts.Responses.Command.GetUniqueTestTagsCommandResponse"
+                },
+                "example": {
+                  "tags": ["string"]
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Testers.DataContracts.Responses.Command.GetUniqueTestTagsCommandResponse": {
+        "type": "object",
+        "properties": {
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Testers.DataContracts.Responses.Command.GetTestByIdCommandResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  }
+}

--- a/modules/openapi/tests/src/DebugSpec.scala
+++ b/modules/openapi/tests/src/DebugSpec.scala
@@ -1,0 +1,64 @@
+/* Copyright 2022 Disney Streaming
+ *
+ * Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package smithytranslate.openapi
+
+import cats.data.NonEmptyList
+import smithytranslate.openapi.OpenApiCompiler.Failure
+import smithytranslate.openapi.OpenApiCompiler.Success
+import software.amazon.smithy.model.validation.ValidatedResultException
+import munit.Location
+
+final class DebugSpec extends munit.FunSuite {
+
+  private def load(fileName: String, debug: Boolean) = {
+    val content = scala.io.Source
+      .fromResource(fileName)
+      .getLines()
+      .mkString("\n")
+    val inputs = Seq((NonEmptyList.of(fileName), content))
+    OpenApiCompiler.parseAndCompile(
+      OpenApiCompiler.Options(
+        useVerboseNames = false,
+        failOnValidationErrors = false,
+        List.empty,
+        useEnumTraitSyntax = false,
+        debug
+      ),
+      inputs: _*
+    )
+  }
+
+  private def testFilteredErrors(debug: Boolean, expectedCount: Int)(implicit
+      loc: Location
+  ) = {
+    load("issue-23.json", debug) match {
+      case Failure(ex: ValidatedResultException, _) =>
+        assertEquals(ex.getValidationEvents().size(), expectedCount)
+      case Failure(cause, _) =>
+        fail(
+          s"expected a ValidatedResultException but got a ${cause.getClass().getSimpleName()}"
+        )
+      case Success(_, _) => fail("expected a failure")
+    }
+  }
+
+  test("load with debug leaves validation events untouched") {
+    testFilteredErrors(debug = true, expectedCount = 5)
+  }
+  test("load without debug filters validation events") {
+    testFilteredErrors(debug = false, expectedCount = 2)
+  }
+}

--- a/modules/openapi/tests/src/TestUtils.scala
+++ b/modules/openapi/tests/src/TestUtils.scala
@@ -94,7 +94,8 @@ object TestUtils {
           useVerboseNames = false,
           failOnValidationErrors = false,
           List.empty,
-          input0.smithyVersion == SmithyVersion.One
+          input0.smithyVersion == SmithyVersion.One,
+          debug = true
         ),
         inputs.map(i => i.filePath -> i.openapiSpec): _*
       )

--- a/modules/readme-validator/src/Validator.scala
+++ b/modules/readme-validator/src/Validator.scala
@@ -91,7 +91,8 @@ object Validator {
         useVerboseNames = false,
         failOnValidationErrors = true,
         List.empty,
-        useEnumTraitSyntax = false
+        useEnumTraitSyntax = false,
+        debug = false
       )
     val result =
       OpenApiCompiler.parseAndCompile(
@@ -133,7 +134,8 @@ object Validator {
         useVerboseNames = false,
         failOnValidationErrors = true,
         List.empty,
-        useEnumTraitSyntax = false
+        useEnumTraitSyntax = false,
+        debug = false
       )
     val result =
       JsonSchemaCompiler.parseAndCompile(


### PR DESCRIPTION
Refs #23 

Currently, it only tweaks the validated result exception but
it could be used for other things. Current implementation rebuild
the exception with only DANGER and ERROR validation event when debug
is false. Which is the default.

It looks like this:

```
An error occurred while importing your Open API resources.
software.amazon.smithy.model.validation.ValidatedResultException: Result contained ERROR severity validation events:
[ERROR] issue_23#TestersGetTest: Operation URI, `/Testers/{id}`, conflicts with other operation URIs in the same service: [`issue_23#TestersGetTestTags` (/Testers/queries/unique-tags)] | HttpUriConflict N/A:0:0
[ERROR] issue_23#TestersGetTestTags: Operation URI, `/Testers/queries/unique-tags`, conflicts with other operation URIs in the same service: [`issue_23#TestersGetTest` (/Testers/{id})] | HttpUriConflict N/A:0:0
	at smithytranslate.openapi.OpenApiCompiler$Options.$anonfun$debugModelValidationError$1(OpenApiCompiler.scala:97)
	at cats.syntax.EitherOps$.leftMap$extension(either.scala:193)
	at smithytranslate.openapi.OpenApiCompiler$.compile(OpenApiCompiler.scala:159)
	at smithytranslate.openapi.OpenApiCompiler$.parseAndCompile(OpenApiCompiler.scala:142)
	at smithytranslate.cli.runners.openapi.ParseAndCompile$.openapi(ParseAndCompile.scala:42)
	at smithytranslate.cli.runners.OpenApi$.runOpenApi(OpenApi.scala:36)
	at smithytranslate.cli.Main$$anonfun$$lessinit$greater$1.apply(Main.scala:34)
	at smithytranslate.cli.Main$$anonfun$$lessinit$greater$1.apply(Main.scala:32)
	at scala.Function1.$anonfun$andThen$1(Function1.scala:85)
	at scala.Function1.$anonfun$andThen$1(Function1.scala:85)
	at cats.data.Validated.andThen(Validated.scala:727)
	at com.monovore.decline.Result.$anonfun$mapValidated$2(Result.scala:13)
	at cats.instances.Function0Instances$$anon$4.$anonfun$map$1(function.scala:96)
	at com.monovore.decline.Parser.evalResult(Parser.scala:30)
	at com.monovore.decline.Parser.$anonfun$consumeAll$3(Parser.scala:107)
	at scala.util.Either.flatMap(Either.scala:352)
	at com.monovore.decline.Parser.$anonfun$consumeAll$1(Parser.scala:107)
	at scala.Option.map(Option.scala:242)
	at com.monovore.decline.Parser.consumeAll(Parser.scala:106)
	at com.monovore.decline.Parser.apply(Parser.scala:19)
	at com.monovore.decline.Command.parse(opts.scala:20)
	at smithytranslate.cli.CommandApp.main(CommandApp.scala:81)
	at smithytranslate.cli.Main.main(Main.scala)

```

When debug is set to true, you see all validation events:

```
An error occurred while importing your Open API resources.
software.amazon.smithy.model.validation.ValidatedResultException: Result contained ERROR severity validation events:
[ERROR] issue_23#TestersGetTest: Operation URI, `/Testers/{id}`, conflicts with other operation URIs in the same service: [`issue_23#TestersGetTestTags` (/Testers/queries/unique-tags)] | HttpUriConflict N/A:0:0
[ERROR] issue_23#TestersGetTestTags: Operation URI, `/Testers/queries/unique-tags`, conflicts with other operation URIs in the same service: [`issue_23#TestersGetTest` (/Testers/{id})] | HttpUriConflict N/A:0:0
[SUPPRESSED] smithytranslate#Null: The structure shape is not connected to from any service shape. (This is a library namespace.) | UnreferencedShape /Users/David.Francoeur/workspace/dev/smithy-translate/modules/traits/resources/META-INF/smithy/openapi.smithy:37:1
[WARNING] issue_23#TestersGetTest: This operation uses the `GET` method in the `http` trait, but is not marked with the readonly trait | HttpMethodSemantics N/A:0:0
[WARNING] issue_23#TestersGetTestTags: This operation uses the `GET` method in the `http` trait, but is not marked with the readonly trait | HttpMethodSemantics N/A:0:0
	at software.amazon.smithy.model.validation.ValidatedResult.validate(ValidatedResult.java:145)
	at software.amazon.smithy.model.validation.ValidatedResult.unwrap(ValidatedResult.java:132)
	at smithytranslate.openapi.OpenApiCompiler$.validate(OpenApiCompiler.scala:168)
	at smithytranslate.openapi.OpenApiCompiler$.$anonfun$compile$5(OpenApiCompiler.scala:157)
	at scala.util.Try$.apply(Try.scala:210)
	at smithytranslate.openapi.OpenApiCompiler$.compile(OpenApiCompiler.scala:157)
	at smithytranslate.openapi.OpenApiCompiler$.parseAndCompile(OpenApiCompiler.scala:142)
	at smithytranslate.cli.runners.openapi.ParseAndCompile$.openapi(ParseAndCompile.scala:42)
	at smithytranslate.cli.runners.OpenApi$.runOpenApi(OpenApi.scala:36)
	at smithytranslate.cli.Main$$anonfun$$lessinit$greater$1.apply(Main.scala:34)
	at smithytranslate.cli.Main$$anonfun$$lessinit$greater$1.apply(Main.scala:32)
	at scala.Function1.$anonfun$andThen$1(Function1.scala:85)
	at scala.Function1.$anonfun$andThen$1(Function1.scala:85)
	at cats.data.Validated.andThen(Validated.scala:727)
	at com.monovore.decline.Result.$anonfun$mapValidated$2(Result.scala:13)
	at cats.instances.Function0Instances$$anon$4.$anonfun$map$1(function.scala:96)
	at com.monovore.decline.Parser.evalResult(Parser.scala:30)
	at com.monovore.decline.Parser.$anonfun$consumeAll$3(Parser.scala:107)
	at scala.util.Either.flatMap(Either.scala:352)
	at com.monovore.decline.Parser.$anonfun$consumeAll$1(Parser.scala:107)
	at scala.Option.map(Option.scala:242)
	at com.monovore.decline.Parser.consumeAll(Parser.scala:106)
	at com.monovore.decline.Parser.apply(Parser.scala:19)
	at com.monovore.decline.Command.parse(opts.scala:20)
	at smithytranslate.cli.CommandApp.main(CommandApp.scala:81)
	at smithytranslate.cli.Main.main(Main.scala)

```