### PR TITLE
Bump scala and get rid of the semanticDbVersion

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -95,11 +95,8 @@ trait BasePublishModule extends BaseModule with CiReleaseModule {
   }
 }
 
-trait ScalaVersionModule
-    extends mill.scalalib.bsp.ScalaMetalsSupport
-    with ScalafmtModule {
-  def scalaVersion = T.input("2.13.8")
-  def semanticDbVersion = T.input("4.4.34")
+trait ScalaVersionModule extends ScalaModule with ScalafmtModule {
+  def scalaVersion = T.input("2.13.10")
 
   def scalacOptions = T {
     super.scalacOptions() ++ scalacOptionsFor(scalaVersion())

--- a/modules/cli/src/runners/Proto.scala
+++ b/modules/cli/src/runners/Proto.scala
@@ -107,7 +107,7 @@ private object Deps {
     val validDeps = DependencyParser
       .dependencies(
         dependencies,
-        defaultScalaVersion = "2.13.8"
+        defaultScalaVersion = "2.13.10"
       )
       .either
       .getOrElse(sys.error("Invalid dependency."))

--- a/modules/json-schema/src/internals/Extractors.scala
+++ b/modules/json-schema/src/internals/Extractors.scala
@@ -175,6 +175,9 @@ object Extractors {
   }
 
   object CaseMap {
+    @annotation.nowarn(
+      "msg=method getPatternProperties in class ObjectSchema is deprecated"
+    )
     def unapply(sch: Schema): Option[(List[Hint], Schema)] = sch match {
       // See http://json-schema.org/draft/2020-12/json-schema-core.html#name-patternproperties
       // This is really not easy to represent in a well-typed manner, so we're just accepting

--- a/modules/openapi/src/internals/IModelToSmithy.scala
+++ b/modules/openapi/src/internals/IModelToSmithy.scala
@@ -170,7 +170,9 @@ final class IModelToSmithy(useEnumTraitSyntax: Boolean)
   private def buildEnum(e: Enumeration): Shape = {
     val Enumeration(id, values, hints) = e
     if (useEnumTraitSyntax) {
-      val enumTraitBuilder = EnumTrait.builder()
+      val enumTraitBuilder = EnumTrait.builder(): @annotation.nowarn(
+        "msg=class EnumTrait in package traits is deprecated"
+      )
       values.foreach(v =>
         enumTraitBuilder.addEnum(EnumDefinition.builder.value(v).build())
       )

--- a/modules/proto/core/src/smithyproto/proto3/Compiler.scala
+++ b/modules/proto/core/src/smithyproto/proto3/Compiler.scala
@@ -143,6 +143,7 @@ class Compiler() {
   private def isProtoService(ss: ServiceShape): Boolean =
     ss.hasTrait(classOf[ProtoEnabledTrait])
 
+  @annotation.nowarn("msg=class EnumTrait in package traits is deprecated")
   private def getEnumTrait(s: Shape): Option[EnumTrait] =
     s.getTrait(classOf[EnumTrait]).toScala
 
@@ -587,6 +588,8 @@ class Compiler() {
       def operationShape(shape: OperationShape): Option[Type] = None
       def resourceShape(shape: ResourceShape): Option[Type] = None
       def serviceShape(shape: ServiceShape): Option[Type] = None
+
+      @annotation.nowarn("msg=class SetShape in package shapes is deprecated")
       override def setShape(shape: SetShape): Option[Type] = Some(
         Type.MessageType(
           Namespacing.shapeIdToFqn(shape.getId),

--- a/modules/transitive/src/closure/IdRefVisitor.scala
+++ b/modules/transitive/src/closure/IdRefVisitor.scala
@@ -53,6 +53,7 @@ final class IdRefVisitor(
   def listShape(shape: ListShape): List[Shape] =
     visitSeqShape(shape.getMember())
 
+  @annotation.nowarn("msg=class SetShape in package shapes is deprecated")
   override def setShape(shape: SetShape): List[Shape] =
     visitSeqShape(shape.getMember())
 


### PR DESCRIPTION
Sorry for not being clear, the two are unrelated. I was doing maintenance work and realized that the scala version was outdated.

On top of that, I saw that we're using mill >= 0.10.8, which includes https://github.com/com-lihaoyi/mill/pull/1977/files which means we can get rid of `semanticDbVersion`