### PR TITLE
Fix value assignment 

### DIFF
--- a/modules/formatter/src/ast/Idl.scala
+++ b/modules/formatter/src/ast/Idl.scala
@@ -19,7 +19,7 @@ package ast
 import smithytranslate.formatter.ast.shapes.ShapeSection
 
 case class Idl(
-    ws: Whitespace,
+    ws: Whitespaces,
     control: ControlSection,
     metadata: MetadataSection,
     shape: ShapeSection

--- a/modules/formatter/src/ast/node.scala
+++ b/modules/formatter/src/ast/node.scala
@@ -22,11 +22,11 @@ sealed trait NodeValue
 
 object NodeValue {
   case class NodeArray(
-      whitespace: Whitespace,
-      values: List[(NodeValue, Whitespace)]
+      whitespace: Whitespaces,
+      values: List[(NodeValue, Whitespaces)]
   ) extends NodeValue
   case class NodeObject(
-      whitespace: Whitespace,
+      whitespace: Whitespaces,
       values: Option[
         (NodeObjectKeyValuePair, List[(Whitespace, NodeObjectKeyValuePair)])
       ]
@@ -34,8 +34,8 @@ object NodeValue {
 
   case class NodeObjectKeyValuePair(
       nodeObjectKey: NodeObjectKey,
-      ws0: Whitespace,
-      ws1: Whitespace,
+      ws0: Whitespaces,
+      ws1: Whitespaces,
       nodeValue: NodeValue
   )
 

--- a/modules/formatter/src/ast/node.scala
+++ b/modules/formatter/src/ast/node.scala
@@ -30,7 +30,7 @@ object NodeValue {
   // The grammar says: "{" *WS [NodeObjectKvp *(WS NodeObjectKvp)] *WS "}"
   // If we follow this, then `{ name: "examples.hello", entryPoints: true }` is invalid
   // where as `{ name: "examples.hello" entryPoints: true }` is valid, which does not make
-  // sense
+  // sense.
   case class NodeObject(
       whitespace: Whitespaces,
       values: Option[

--- a/modules/formatter/src/ast/node.scala
+++ b/modules/formatter/src/ast/node.scala
@@ -25,10 +25,16 @@ object NodeValue {
       whitespace: Whitespaces,
       values: List[(NodeValue, Whitespaces)]
   ) extends NodeValue
+
+  // NodeObject is another place where we diverge from the grammar
+  // The grammar says: "{" *WS [NodeObjectKvp *(WS NodeObjectKvp)] *WS "}"
+  // If we follow this, then `{ name: "examples.hello", entryPoints: true }` is invalid
+  // where as `{ name: "examples.hello" entryPoints: true }` is valid, which does not make
+  // sense
   case class NodeObject(
       whitespace: Whitespaces,
       values: Option[
-        (NodeObjectKeyValuePair, List[(Whitespace, NodeObjectKeyValuePair)])
+        (NodeObjectKeyValuePair, List[(Whitespaces, NodeObjectKeyValuePair)])
       ]
   ) extends NodeValue
 

--- a/modules/formatter/src/ast/shapes.scala
+++ b/modules/formatter/src/ast/shapes.scala
@@ -290,6 +290,9 @@ object shapes {
         ]
     )
 
-    case class ValueAssignment(value: NodeValue, break: Break)
+    // The spec adds a BR after the NodeValue
+    // *SP "=" *SP NodeValue BR but it does not make sense
+    // Instead we'll use `*SP "=" *SP NodeValue *WS`
+    case class ValueAssignment(value: NodeValue, whitespace: Whitespaces)
   }
 }

--- a/modules/formatter/src/ast/shapes.scala
+++ b/modules/formatter/src/ast/shapes.scala
@@ -250,24 +250,33 @@ object shapes {
         ws1: Whitespaces
     )
 
+    // Diverging from the grammar:
+    // `%s"input" *WS (InlineStructure / (":" *WS ShapeId)) WS` vs
+    // `%s"input" *WS (InlineStructure / (":" *WS ShapeId)) *WS`
     case class OperationInput(
         whitespace: Whitespaces,
         either: Either[InlineStructure, (Whitespaces, ShapeId)],
-        whitespace1: Whitespace
+        whitespace1: Whitespaces
     )
 
+    // Diverging from the grammar:
+    // `%s"output" *WS (InlineStructure / (":" *WS ShapeId)) WS` vs
+    // `%s"output" *WS (InlineStructure / (":" *WS ShapeId)) *WS`
     case class OperationOutput(
         whitespace: Whitespaces,
         either: Either[InlineStructure, (Whitespaces, ShapeId)],
-        whitespace1: Whitespace
+        whitespace1: Whitespaces
     )
 
+    // Diverging from the grammar:
+    // `%s"errors" *WS ":" *WS "[" *(*WS Identifier) *WS "]" WS` vs
+    // `%s"errors" *WS ":" *WS "[" *(*WS Identifier) *WS "]" *WS`
     case class OperationErrors(
         ws0: Whitespaces,
         ws1: Whitespaces,
         list: List[(Whitespaces, Identifier)],
         ws2: Whitespaces,
-        ws3: Whitespace
+        ws3: Whitespaces
     )
 
     case class OperationStatement(

--- a/modules/formatter/src/ast/shapes.scala
+++ b/modules/formatter/src/ast/shapes.scala
@@ -99,14 +99,14 @@ object shapes {
         typeName: String,
         id: Identifier,
         mixin: Option[Mixin],
-        whitespace: Whitespace,
+        whitespace: Whitespaces,
         enumShapeMembers: EnumShapeMembers
     ) extends ShapeBody
 
     case class ListStatement(
         identifier: Identifier,
         mixin: Option[Mixin],
-        whitespace: Whitespace,
+        whitespace: Whitespaces,
         members: ListMembers
     ) extends ShapeBody
 
@@ -118,9 +118,9 @@ object shapes {
       case class ExplicitListMember(shapeId: ShapeId) extends ListMemberType
 
       case class ListMembers(
-          ws0: Whitespace,
+          ws0: Whitespaces,
           members: ListMember,
-          ws1: Whitespace
+          ws1: Whitespaces
       )
 
       case class ListMember(
@@ -132,7 +132,7 @@ object shapes {
     case class MapStatement(
         identifier: Identifier,
         mixin: Option[Mixin],
-        whitespace: Whitespace,
+        whitespace: Whitespaces,
         members: MapMembers
     ) extends ShapeBody
 
@@ -164,11 +164,11 @@ object shapes {
       }
 
       case class MapMembers(
-          ws0: Whitespace,
+          ws0: Whitespaces,
           mapKey: MapKey,
-          break: Whitespace,
+          whitespace: Whitespace,
           mapValue: MapValue,
-          ws1: Whitespace
+          ws1: Whitespaces
       )
     }
 
@@ -176,15 +176,15 @@ object shapes {
         identifier: Identifier,
         resource: Option[StructureResource],
         mixins: Option[Mixin],
-        whitespace: Whitespace,
+        whitespace: Whitespaces,
         members: StructureMembers
     ) extends ShapeBody
 
     case class StructureResource(shapeId: ShapeId)
 
     case class StructureMembers(
-        ws0: Whitespace,
-        members: List[(TraitStatements, StructureMember, Whitespace)]
+        ws0: Whitespaces,
+        members: List[(TraitStatements, StructureMember, Whitespaces)]
     )
 
     object StructureMembers {
@@ -209,13 +209,13 @@ object shapes {
     case class UnionStatement(
         identifier: Identifier,
         mixin: Option[Mixin],
-        whitespace: Whitespace,
+        whitespace: Whitespaces,
         members: UnionMembers
     ) extends ShapeBody
 
     case class UnionMembers(
-        whitespace: Whitespace,
-        members: List[(TraitStatements, UnionMember, Whitespace)]
+        whitespace: Whitespaces,
+        members: List[(TraitStatements, UnionMember, Whitespaces)]
     )
 
     case class UnionMember(structureMemberType: StructureMemberType)
@@ -223,69 +223,70 @@ object shapes {
     case class ServiceStatement(
         identifier: Identifier,
         mixin: Option[Mixin],
-        whitespace1: Whitespace,
+        whitespace1: Whitespaces,
         nodeObject: NodeObject
     ) extends ShapeBody
 
     case class ResourceStatement(
         identifier: Identifier,
         mixin: Option[Mixin],
-        whitespace: Whitespace,
+        whitespace: Whitespaces,
         nodeObject: NodeObject
     ) extends ShapeBody
 
     case class InlineStructure(
-        whitespace: Whitespace,
+        whitespace: Whitespaces,
         traitStatements: TraitStatements,
         mixin: Option[Mixin],
-        ws1: Whitespace,
+        ws1: Whitespaces,
         members: StructureMembers
     )
 
     case class OperationBody(
-        whitespace: Whitespace,
+        whitespace: Whitespaces,
         input: Option[OperationInput],
         output: Option[OperationOutput],
         errors: Option[OperationErrors],
-        ws1: Whitespace
+        ws1: Whitespaces
     )
 
     case class OperationInput(
-        whitespace: Whitespace,
-        either: Either[InlineStructure, (Whitespace, ShapeId)],
+        whitespace: Whitespaces,
+        either: Either[InlineStructure, (Whitespaces, ShapeId)],
         whitespace1: Whitespace
     )
 
     case class OperationOutput(
-        whitespace: Whitespace,
-        either: Either[InlineStructure, (Whitespace, ShapeId)],
+        whitespace: Whitespaces,
+        either: Either[InlineStructure, (Whitespaces, ShapeId)],
         whitespace1: Whitespace
     )
 
     case class OperationErrors(
-        ws0: Whitespace,
-        ws1: Whitespace,
-        list: List[(Whitespace, Identifier)],
-        ws2: Whitespace
+        ws0: Whitespaces,
+        ws1: Whitespaces,
+        list: List[(Whitespaces, Identifier)],
+        ws2: Whitespaces,
+        ws3: Whitespace
     )
 
     case class OperationStatement(
         identifier: Identifier,
         mixin: Option[Mixin],
-        whitespace: Whitespace,
+        whitespace: Whitespaces,
         operationBody: OperationBody
     ) extends ShapeBody
 
     case class Mixin(
-        whitespace: Whitespace,
-        shapeIds: NonEmptyList[(Whitespace, ShapeId)],
-        whitespace1: Whitespace
+        whitespace: Whitespaces,
+        shapeIds: NonEmptyList[(Whitespaces, ShapeId)],
+        whitespace1: Whitespaces
     )
 
     case class EnumShapeMembers(
-        whitespace: Whitespace,
+        whitespace: Whitespaces,
         members: NonEmptyList[
-          (TraitStatements, Identifier, Option[ValueAssignment], Whitespace)
+          (TraitStatements, Identifier, Option[ValueAssignment], Whitespaces)
         ]
     )
 

--- a/modules/formatter/src/ast/smithyTrait.scala
+++ b/modules/formatter/src/ast/smithyTrait.scala
@@ -19,16 +19,16 @@ package ast
 import NodeValue.NodeObjectKey
 
 case class TraitStatements(
-    list: List[(Whitespace, SmithyTrait)],
-    after: Whitespace
+    list: List[(Whitespaces, SmithyTrait)],
+    after: Whitespaces
 )
 
 case class SmithyTrait(shapeId: ShapeId, traitBody: Option[TraitBody])
 
 case class TraitBody(
-    ws0: Whitespace,
+    ws0: Whitespaces,
     traitBodyValue: Option[SmithyTraitBodyValue],
-    ws1: Whitespace
+    ws1: Whitespaces
 )
 
 sealed trait SmithyTraitBodyValue
@@ -47,8 +47,8 @@ case class TraitStructure(
 
 case class TraitStructureKeyValuePair(
     nodeObjectKey: NodeObjectKey,
-    ws0: Whitespace,
-    ws1: Whitespace,
+    ws0: Whitespaces,
+    ws1: Whitespaces,
     nodeValue: NodeValue
 )
 //ApplyStatement =

--- a/modules/formatter/src/ast/smithyTrait.scala
+++ b/modules/formatter/src/ast/smithyTrait.scala
@@ -42,7 +42,7 @@ object SmithyTraitBodyValue {
 
 case class TraitStructure(
     traitStructureKVP: TraitStructureKeyValuePair,
-    additionalTraits: List[(Whitespace, TraitStructureKeyValuePair)]
+    additionalTraits: List[(Whitespaces, TraitStructureKeyValuePair)]
 )
 
 case class TraitStructureKeyValuePair(

--- a/modules/formatter/src/ast/whitespace.scala
+++ b/modules/formatter/src/ast/whitespace.scala
@@ -19,7 +19,10 @@ package ast
 import smithytranslate.formatter.ast.CommentType.{Documentation, Line}
 
 case object Comma {}
-case class Whitespace(whitespace: List[Comment])
+case class Whitespace(comment: Option[Comment]) {
+  def toWhitespaces: Whitespaces = Whitespaces(comment.toList)
+}
+case class Whitespaces(comments: List[Comment])
 
 case class Break(newLineOrComment: List[Comment])
 sealed trait CommentType { self =>

--- a/modules/formatter/src/parsers/IdlParser.scala
+++ b/modules/formatter/src/parsers/IdlParser.scala
@@ -17,7 +17,7 @@ package formatter
 package parsers
 
 import cats.parse.Parser0
-import smithytranslate.formatter.parsers.WhitespaceParser.ws
+import smithytranslate.formatter.parsers.WhitespaceParser.ws0
 import smithytranslate.formatter.ast.Idl
 import smithytranslate.formatter.parsers.ControlParser.control_section
 import MetadataParser.metadata_section
@@ -26,7 +26,7 @@ import ShapeParser.shape_section
 object IdlParser {
 
   val idlParser: Parser0[Idl] =
-    (ws ~ control_section ~ metadata_section ~ shape_section).map {
+    (ws0 ~ control_section ~ metadata_section ~ shape_section).map {
       case (((whitespace, control), metadata), shape) =>
         Idl(whitespace, control, metadata, shape)
     }

--- a/modules/formatter/src/parsers/NodeParser.scala
+++ b/modules/formatter/src/parsers/NodeParser.scala
@@ -33,7 +33,7 @@ import smithytranslate.formatter.ast.QuotedChar.{
   PreservedDoubleCase,
   SimpleCharCase
 }
-import smithytranslate.formatter.parsers.WhitespaceParser.{nl, sp0, ws}
+import smithytranslate.formatter.parsers.WhitespaceParser.{nl, sp0, ws, ws0}
 import smithytranslate.formatter.ast.{
   EscapedChar,
   NodeValue,
@@ -97,18 +97,18 @@ object NodeParser {
     ) | identifier.map(NodeObjectKey.IdentifierNok)
 
   lazy val node_object_kvp: Parser[NodeObjectKeyValuePair] =
-    ((node_object_key ~ ws <* Parser.char(':')) ~ ws ~ node_value).map {
+    ((node_object_key ~ ws0 <* Parser.char(':')) ~ ws0 ~ node_value).map {
       case (((a, b), c), d) => NodeObjectKeyValuePair(a, b, c, d)
     }
 
   val nodeObject: Parser[NodeObject] =
-    (openCurly *> ws ~ (node_object_kvp ~ (ws.with1 ~ node_object_kvp).backtrack.rep0).?.backtrack <* (ws ~ closeCurly))
+    (openCurly *> ws0 ~ (node_object_kvp ~ (ws.with1 ~ node_object_kvp).backtrack.rep0).?.backtrack <* (ws0 ~ closeCurly))
       .map { case (whitespace, maybeTuple) =>
         NodeObject(whitespace, maybeTuple)
       }
 
   val nodeArray: Parser[NodeArray] =
-    ((openSquare *> ws ~ (node_value ~ ws).backtrack.rep0) <* (ws ~ closeSquare))
+    ((openSquare *> ws0 ~ (node_value ~ ws0).backtrack.rep0) <* (ws0 ~ closeSquare))
       .map { case (whitespace, maybeTuple) =>
         NodeArray(whitespace, maybeTuple)
       }

--- a/modules/formatter/src/parsers/NodeParser.scala
+++ b/modules/formatter/src/parsers/NodeParser.scala
@@ -33,7 +33,7 @@ import smithytranslate.formatter.ast.QuotedChar.{
   PreservedDoubleCase,
   SimpleCharCase
 }
-import smithytranslate.formatter.parsers.WhitespaceParser.{nl, sp0, ws, ws0}
+import smithytranslate.formatter.parsers.WhitespaceParser.{nl, sp0, ws0}
 import smithytranslate.formatter.ast.{
   EscapedChar,
   NodeValue,
@@ -102,7 +102,7 @@ object NodeParser {
     }
 
   val nodeObject: Parser[NodeObject] =
-    (openCurly *> ws0 ~ (node_object_kvp ~ (ws.with1 ~ node_object_kvp).backtrack.rep0).?.backtrack <* (ws0 ~ closeCurly))
+    (openCurly *> ws0 ~ (node_object_kvp ~ (ws0.with1 ~ node_object_kvp).backtrack.rep0).?.backtrack <* (ws0 ~ closeCurly))
       .map { case (whitespace, maybeTuple) =>
         NodeObject(whitespace, maybeTuple)
       }

--- a/modules/formatter/src/parsers/ShapeParser.scala
+++ b/modules/formatter/src/parsers/ShapeParser.scala
@@ -255,19 +255,19 @@ object ShapeParser {
     val operation_input: Parser[OperationInput] =
       (Parser.string("input") *> ws0 ~ ir.backtrack.eitherOr(
         inline_structure
-      ) ~ ws).map { case ((ws0, either), ws1) =>
+      ) ~ ws0).map { case ((ws0, either), ws1) =>
         OperationInput(ws0, either, ws1)
       }
     val operation_output: Parser[OperationOutput] =
       (Parser.string("output") *> ws0 ~ ir.backtrack.eitherOr(
         inline_structure
-      ) ~ ws).map { case ((ws0, either), ws1) =>
+      ) ~ ws0).map { case ((ws0, either), ws1) =>
         OperationOutput(ws0, either, ws1)
       }
     val operation_errors: Parser[OperationErrors] =
       ((((Parser.string("errors") *> ws0 <* Parser.char(
         ':'
-      )) ~ ws0 <* openSquare) ~ (ws0.with1 ~ identifier).backtrack.rep0 ~ ws0 <* closeSquare) ~ ws)
+      )) ~ ws0 <* openSquare) ~ (ws0.with1 ~ identifier).backtrack.rep0 ~ ws0 <* closeSquare) ~ ws0)
         .map { case ((((ws0, ws1), indentifiers), ws2), ws3) =>
           OperationErrors(ws0, ws1, indentifiers, ws2, ws3)
         }

--- a/modules/formatter/src/parsers/ShapeParser.scala
+++ b/modules/formatter/src/parsers/ShapeParser.scala
@@ -86,9 +86,8 @@ object ShapeParser {
   val enum_type_name: Parser[String] = Parser.stringIn(enumTypeNames)
 
   val value_assigments: Parser[ValueAssignment] =
-    (sp *> Parser.char('=') *> sp *> node_value ~ br).map { case (l, r) =>
-      println(l)
-      println(r)
+    // see comments on ValueAssignment
+    (sp *> Parser.char('=') *> sp *> node_value ~ ws0).map { case (l, r) =>
       ValueAssignment(l, r)
     }
 

--- a/modules/formatter/src/parsers/SmithyTraitParser.scala
+++ b/modules/formatter/src/parsers/SmithyTraitParser.scala
@@ -38,7 +38,7 @@ object SmithyTraitParser {
     }
   //       TraitStructureKvp *(*WS TraitStructureKvp)
   val trait_structure: Parser[TraitStructure] =
-    (trait_structure_kvp ~ (ws.with1 ~ trait_structure_kvp).backtrack.rep0)
+    (trait_structure_kvp ~ (ws0.with1 ~ trait_structure_kvp).backtrack.rep0)
       .map(TraitStructure.tupled)
 
   //    trait_structure / node_value

--- a/modules/formatter/src/parsers/SmithyTraitParser.scala
+++ b/modules/formatter/src/parsers/SmithyTraitParser.scala
@@ -21,7 +21,7 @@ import smithytranslate.formatter.ast.SmithyTraitBodyValue.{
   NodeValueCase,
   SmithyTraitStructureCase
 }
-import smithytranslate.formatter.parsers.WhitespaceParser.{br, sp, ws}
+import smithytranslate.formatter.parsers.WhitespaceParser.{br, sp, ws, ws0}
 import smithytranslate.formatter.ast.*
 import smithytranslate.formatter.parsers.NodeParser.{
   node_object_key,
@@ -33,7 +33,7 @@ object SmithyTraitParser {
 
   //    node_object_key ws ":" ws node_value
   val trait_structure_kvp: Parser[TraitStructureKeyValuePair] =
-    ((node_object_key ~ ws <* Parser.char(':')) ~ ws ~ node_value).map {
+    ((node_object_key ~ ws0 <* Parser.char(':')) ~ ws0 ~ node_value).map {
       case (((a, b), c), d) => TraitStructureKeyValuePair(a, b, c, d)
     }
   //       TraitStructureKvp *(*WS TraitStructureKvp)
@@ -48,7 +48,7 @@ object SmithyTraitParser {
     )
   //  "(" ws trait_body_value ws ")"
   val strait_body: Parser0[TraitBody] =
-    ((openParentheses *> ws ~ strait_body_value.? ~ ws) <* closeParentheses)
+    ((openParentheses *> ws0 ~ strait_body_value.? ~ ws0) <* closeParentheses)
       .map { case ((a, b), c) =>
         TraitBody(a, b, c)
       }
@@ -57,7 +57,7 @@ object SmithyTraitParser {
     Parser.char('@') *> (shape_id ~ strait_body.?).map { SmithyTrait.tupled }
   // *(ws trait) ws
   val trait_statements: Parser0[TraitStatements] =
-    ((ws.with1 ~ strait).backtrack.rep0 ~ ws).map { case (traits, ws) =>
+    ((ws0.with1 ~ strait).backtrack.rep0 ~ ws0).map { case (traits, ws) =>
       TraitStatements(traits, ws)
     }
   val apply_singular: Parser[ApplyStatementSingular] =

--- a/modules/formatter/src/writer/IdlWriter.scala
+++ b/modules/formatter/src/writer/IdlWriter.scala
@@ -20,7 +20,7 @@ import ast.Idl
 import ControlWriter.controlSectionWriter
 import MetadataWriter.metadataSectionWriter
 import ShapeWriter.shapeSectionWriter
-import WhiteSpaceWriter.wsWriter
+import WhiteSpaceWriter.wssWriter
 import Writer.WriterOps
 
 object IdlWriter {

--- a/modules/formatter/src/writer/NodeWriter.scala
+++ b/modules/formatter/src/writer/NodeWriter.scala
@@ -48,7 +48,7 @@ import ast.QuotedChar.{
 }
 import util.string_ops.{addBrackets, indent}
 import ShapeIdWriter.{identifierWriter, shapeIdWriter}
-import WhiteSpaceWriter.{wsWriter, wssWriter}
+import WhiteSpaceWriter.wssWriter
 import Writer.{WriterOps, WriterOpsIterable}
 
 object NodeWriter {

--- a/modules/formatter/src/writer/NodeWriter.scala
+++ b/modules/formatter/src/writer/NodeWriter.scala
@@ -48,7 +48,7 @@ import ast.QuotedChar.{
 }
 import util.string_ops.{addBrackets, indent}
 import ShapeIdWriter.{identifierWriter, shapeIdWriter}
-import WhiteSpaceWriter.wsWriter
+import WhiteSpaceWriter.{wsWriter, wssWriter}
 import Writer.{WriterOps, WriterOpsIterable}
 
 object NodeWriter {

--- a/modules/formatter/src/writer/ShapeWriter.scala
+++ b/modules/formatter/src/writer/ShapeWriter.scala
@@ -110,7 +110,8 @@ object ShapeWriter {
   }
 
   implicit val valueAssignmentWriter: Writer[ValueAssignment] = Writer.write {
-    case ValueAssignment(value, break) => s"${value.write}${break.write}"
+    case ValueAssignment(value, whitespace) =>
+      s" = ${value.write}${whitespace.write}"
   }
 
   implicit val enumShapeMembersWriter: Writer[EnumShapeMembers] = Writer.write {
@@ -120,7 +121,7 @@ object ShapeWriter {
           s"${ts.write}${identifiers.write}${maybeValue.write}${ws.write}"
         }
         .toList
-        .mkString_("", ",\n", ",")
+        .mkString_("", "\n", "")
       s"${whitespace.write}${memberLines}"
   }
   implicit val structureMemberTypeWriter: Writer[StructureMemberType] =

--- a/modules/formatter/src/writer/ShapeWriter.scala
+++ b/modules/formatter/src/writer/ShapeWriter.scala
@@ -42,7 +42,7 @@ import ShapeIdWriter.{
   shapeIdWriter
 }
 import SmithyTraitWriter.{applyStatementWriter, traitStatementsWriter}
-import WhiteSpaceWriter.{breakWriter, wsWriter}
+import WhiteSpaceWriter.{breakWriter, wsWriter, wssWriter}
 import Writer.{WriterOps, WriterOpsIterable}
 
 object ShapeWriter {
@@ -170,13 +170,13 @@ object ShapeWriter {
       s"output: ${ws0.write}${members.write}${ws1.write}"
   }
   implicit val operationErrorsWriter: Writer[OperationErrors] = Writer.write {
-    case OperationErrors(ws0, ws1, list, ws3) =>
+    case OperationErrors(ws0, ws1, list, ws2, ws3) =>
       val listLine = list
         .map { case (ws, shapeId) =>
           s"${ws.write}${shapeId.write}"
         }
         .mkString_("[", ", ", ",]")
-      s"errors: ${ws0.write}${ws1.write}${listLine}${ws3.write}"
+      s"errors: ${ws0.write}${ws1.write}${listLine}${ws2.write}${ws3.write}"
   }
   implicit val operationBodyWriter: Writer[OperationBody] = Writer.write {
     case OperationBody(whitespace, input, output, errors, ws1) =>

--- a/modules/formatter/src/writer/SmithyTraitWriter.scala
+++ b/modules/formatter/src/writer/SmithyTraitWriter.scala
@@ -31,7 +31,7 @@ import ast.SmithyTraitBodyValue.{NodeValueCase, SmithyTraitStructureCase}
 import util.string_ops.formatEnum
 import NodeWriter.nodeValueWriter
 import ShapeIdWriter.shapeIdWriter
-import WhiteSpaceWriter.{breakWriter, wsWriter}
+import WhiteSpaceWriter.{breakWriter, wsWriter, wssWriter}
 import Writer.{WriterOps, WriterOpsIterable}
 
 object SmithyTraitWriter {

--- a/modules/formatter/src/writer/WhiteSpaceWriter.scala
+++ b/modules/formatter/src/writer/WhiteSpaceWriter.scala
@@ -16,7 +16,7 @@ package smithytranslate
 package formatter
 package writers
 
-import smithytranslate.formatter.ast.{Break, Comment, Whitespace}
+import smithytranslate.formatter.ast.{Break, Comment, Whitespace, Whitespaces}
 import smithytranslate.formatter.writers.Writer.WriterOpsIterable
 
 object WhiteSpaceWriter {
@@ -35,8 +35,10 @@ object WhiteSpaceWriter {
       s"${commentType.write}${prefixWithWhiteSpace(text)}\n"
   }
   implicit val wsWriter: Writer[Whitespace] =
+    Writer.write(w => wssWriter.write(w.toWhitespaces))
+  implicit val wssWriter: Writer[Whitespaces] =
     Writer.write(
-      _.whitespace.writeN
+      _.comments.writeN
     )
 
   /*

--- a/modules/formatter/src/writer/package.scala
+++ b/modules/formatter/src/writer/package.scala
@@ -15,19 +15,19 @@
 package smithytranslate
 package formatter
 
-import ast.{NodeValue, Whitespace}
+import ast.{NodeValue, Whitespaces}
 import smithytranslate.formatter.writers.NodeWriter.{
   nodeObjectKeyWriter,
   nodeValueWriter
 }
-import smithytranslate.formatter.writers.WhiteSpaceWriter.wsWriter
+import smithytranslate.formatter.writers.WhiteSpaceWriter.wssWriter
 import smithytranslate.formatter.writers.Writer.WriterOps
 
 package object writers {
   def showKeyValue(
       nodeObjectKey: NodeValue.NodeObjectKey,
-      ws0: Whitespace,
-      ws1: Whitespace,
+      ws0: Whitespaces,
+      ws1: Whitespaces,
       nodeValue: NodeValue
   ) = {
     s"${nodeObjectKey.write}${ws0.write}: ${ws1.write}${nodeValue.write}"

--- a/modules/formatter/tests/src/FormatterSpec.scala
+++ b/modules/formatter/tests/src/FormatterSpec.scala
@@ -209,14 +209,23 @@ final class FormatterSpec extends munit.FunSuite {
                  |  VALUE1,
                  |    VALUE2
                  |}
+                 |enum OtherEnum {
+                 |  V1 = "v1"
+                 |V2 = "v2"
+                 |}
                  |""".stripMargin
     val expected = """|$version: "2.0"
                       |
                       |namespace test
                       |
                       |enum MyEnum {
-                      |    VALUE1,
-                      |    VALUE2,
+                      |    VALUE1
+                      |    VALUE2
+                      |}
+                      |
+                      |enum OtherEnum {
+                      |    V1 = "v1"
+                      |    V2 = "v2"
                       |}
                       |
                       |""".stripMargin
@@ -233,6 +242,10 @@ final class FormatterSpec extends munit.FunSuite {
                  |  that: Integer
                  |}
                  |
+                 |structure MyStructDefault {
+                 |  other: Integer = 1
+                 |}
+                 |
                  |union MyUnion {
                  | this: String,
                  |orThat: Integer
@@ -245,6 +258,10 @@ final class FormatterSpec extends munit.FunSuite {
                       |structure MyStruct {
                       |    this: String,
                       |    that: Integer
+                      |}
+                      |
+                      |structure MyStructDefault {
+                      |    other: Integer = 1
                       |}
                       |
                       |union MyUnion {

--- a/modules/formatter/tests/src/ParserSpec.scala
+++ b/modules/formatter/tests/src/ParserSpec.scala
@@ -76,6 +76,32 @@ final class ParserSpec extends munit.FunSuite {
     assertEitherIsRight(result)
   }
 
+  /*
+@readonly
+@http(method: "GET", uri: "/filmography/{actorId}")
+///Get the [Filmography] for the specified actor
+operation GetFilmography {
+  input: ActorInput,
+  output: Filmography
+}
+   */
+
+  test("operation") {
+    val result =
+      IdlParser.idlParser.parseAll(
+        """|$version: "2.0"
+           |
+           |namespace test
+           |
+           |operation GetFilmography {
+           |  input: ActorInput
+           |  output: Filmography
+           |}
+           |""".stripMargin
+      )
+    assert(result.isRight, s"Failed with ${result.swap.getOrElse(fail("err"))}")
+  }
+
   test("enum with commas") {
     val result =
       IdlParser.idlParser.parseAll(

--- a/modules/formatter/tests/src/ParserSpec.scala
+++ b/modules/formatter/tests/src/ParserSpec.scala
@@ -36,7 +36,8 @@ final class ParserSpec extends munit.FunSuite {
     assert(result.isRight && result.exists(_.list.size == 1))
   }
   test("both") {
-    val result = IdlParser.idlParser.parseAll(controlStatement + metadataStatement)
+    val result =
+      IdlParser.idlParser.parseAll(controlStatement + metadataStatement)
     assert(
       result.isRight && result.exists(res =>
         res.metadata.metadata.size == 2 && res.control.list.size == 1
@@ -44,4 +45,19 @@ final class ParserSpec extends munit.FunSuite {
     )
   }
 
+  test("enum with commas") {
+    val result =
+      IdlParser.idlParser.parseAll(
+        """|$version: "2.0"
+           |
+           |namespace test
+           |
+           |enum OtherEnum {
+           |    V1 = "v1",
+           |    V2 = "v2"
+           |}
+           |""".stripMargin
+      )
+    assert(result.isRight, s"Failed with ${result.swap.getOrElse(fail("err"))}")
+  }
 }

--- a/modules/formatter/tests/src/ParserSpec.scala
+++ b/modules/formatter/tests/src/ParserSpec.scala
@@ -102,6 +102,22 @@ operation GetFilmography {
     assert(result.isRight, s"Failed with ${result.swap.getOrElse(fail("err"))}")
   }
 
+  test("trait") {
+    val result =
+      IdlParser.idlParser.parseAll(
+        """|$version: "2.0"
+           |
+           |namespace test
+           |
+           |@http(method: "GET", uri: "/filmography/{actorId}")
+           |structure GetFilmography {
+           |  input: String,
+           |}
+           |""".stripMargin
+      )
+    assert(result.isRight, s"Failed with ${result.swap.getOrElse(fail("err"))}")
+  }
+
   test("enum with commas") {
     val result =
       IdlParser.idlParser.parseAll(


### PR DESCRIPTION
Extract from one of the commits:
```
In this commit, we diverge from the specification. I've commented
on a similar issue that was resolved a few days ago. My hopes
are that a similar resolution is applied and the divergence is no
more.

In short, the grammar states that a value assignment should look
like this:

`ValueAssignment = *SP "=" *SP NodeValue BR`

But this BR is counter-intuitive and probably what's intended
is a `*WS` which is what this commits implements.

This fixes formatter issues with Enum and Structure which both
can define ValueAssignment on their members
```