### PR TITLE
Fix enum support

### DIFF
--- a/modules/formatter/src/ast/shapes.scala
+++ b/modules/formatter/src/ast/shapes.scala
@@ -288,7 +288,9 @@ object shapes {
           (TraitStatements, Identifier, Option[ValueAssignment], Whitespace)
         ]
     )
-
-    case class ValueAssignment(value: NodeValue, break: Break)
+    // The spec adds a BR after the NodeValue
+    // *SP "=" *SP NodeValue BR but it does not make sense
+    // Instead we'll use `*SP "=" *SP NodeValue *WS`
+    case class ValueAssignment(value: NodeValue, break: Whitespace)
   }
 }

--- a/modules/formatter/src/parsers/ShapeParser.scala
+++ b/modules/formatter/src/parsers/ShapeParser.scala
@@ -85,8 +85,9 @@ object ShapeParser {
     Parser.stringIn(simpleNames).map(SimpleTypeName)
   val enum_type_name: Parser[String] = Parser.stringIn(enumTypeNames)
 
+  // see comments on ValueAssignment
   val value_assigments: Parser[ValueAssignment] =
-    (sp *> Parser.char('=') *> sp *> node_value ~ br).map { case (l, r) =>
+    (sp *> Parser.char('=') *> sp *> node_value ~ ws).map { case (l, r) =>
       ValueAssignment(l, r)
     }
 

--- a/modules/formatter/src/writer/ShapeWriter.scala
+++ b/modules/formatter/src/writer/ShapeWriter.scala
@@ -110,7 +110,8 @@ object ShapeWriter {
   }
 
   implicit val valueAssignmentWriter: Writer[ValueAssignment] = Writer.write {
-    case ValueAssignment(value, break) => s"${value.write}${break.write}"
+    case ValueAssignment(value, whitespace) =>
+      s" = ${value.write}${whitespace.write}"
   }
 
   implicit val enumShapeMembersWriter: Writer[EnumShapeMembers] = Writer.write {
@@ -120,7 +121,7 @@ object ShapeWriter {
           s"${ts.write}${identifiers.write}${maybeValue.write}${ws.write}"
         }
         .toList
-        .mkString_("", ",\n", ",")
+        .mkString_("", "\n", "")
       s"${whitespace.write}${memberLines}"
   }
   implicit val structureMemberTypeWriter: Writer[StructureMemberType] =

--- a/modules/formatter/tests/src/FormatterSpec.scala
+++ b/modules/formatter/tests/src/FormatterSpec.scala
@@ -209,14 +209,23 @@ final class FormatterSpec extends munit.FunSuite {
                  |  VALUE1,
                  |    VALUE2
                  |}
+                 |enum OtherEnum {
+                 |  V1 = "v1"
+                 |V2 = "v2"
+                 |}
                  |""".stripMargin
     val expected = """|$version: "2.0"
                       |
                       |namespace test
                       |
                       |enum MyEnum {
-                      |    VALUE1,
-                      |    VALUE2,
+                      |    VALUE1
+                      |    VALUE2
+                      |}
+                      |
+                      |enum OtherEnum {
+                      |    V1 = "v1"
+                      |    V2 = "v2"
                       |}
                       |
                       |""".stripMargin
@@ -233,6 +242,10 @@ final class FormatterSpec extends munit.FunSuite {
                  |  that: Integer
                  |}
                  |
+                 |structure MyStructDefault {
+                 |  other: Integer = 1
+                 |}
+                 |
                  |union MyUnion {
                  | this: String,
                  |orThat: Integer
@@ -245,6 +258,10 @@ final class FormatterSpec extends munit.FunSuite {
                       |structure MyStruct {
                       |    this: String,
                       |    that: Integer
+                      |}
+                      |
+                      |structure MyStructDefault {
+                      |    other: Integer = 1
                       |}
                       |
                       |union MyUnion {

--- a/modules/formatter/tests/src/ParserSpec.scala
+++ b/modules/formatter/tests/src/ParserSpec.scala
@@ -17,8 +17,18 @@ package formatter
 import parsers.ControlParser.control_section
 import smithytranslate.formatter.parsers.IdlParser
 import smithytranslate.formatter.parsers.MetadataParser.metadata_section
+import munit.Location
 
 final class ParserSpec extends munit.FunSuite {
+  private def assertEitherIsRight[T, R](result: Either[T, R])(implicit
+      loc: Location
+  ) = {
+    assert(
+      result.isRight,
+      s"Failed with ${result.swap.getOrElse(fail("Unable to extract error from either"))}"
+    )
+  }
+
   val metadataStatement: String =
     """metadata greeting = "hello"
     metadata "stringList" = ["a", "b", "c"]
@@ -28,20 +38,112 @@ final class ParserSpec extends munit.FunSuite {
 
   test("Parse a metadata statement") {
     val result = metadata_section.parseAll(metadataStatement)
-    assert(result.isRight && result.exists(_.metadata.size == 2))
+    assertEitherIsRight(result)
+    assert(result.exists(_.metadata.size == 2))
   }
 
   test("Parse a control statement") {
     val result = control_section.parseAll(controlStatement)
-    assert(result.isRight && result.exists(_.list.size == 1))
+    assertEitherIsRight(result)
+    assert(result.exists(_.list.size == 1))
   }
+
   test("both") {
-    val result = IdlParser.idlParser.parseAll(controlStatement + metadataStatement)
+    val result =
+      IdlParser.idlParser.parseAll(controlStatement + metadataStatement)
+    assertEitherIsRight(result)
     assert(
-      result.isRight && result.exists(res =>
+      result.exists(res =>
         res.metadata.metadata.size == 2 && res.control.list.size == 1
       )
     )
   }
 
+  test("complex metadata") {
+    val result =
+      IdlParser.idlParser.parseAll("""|$version: "2.0"
+                                      |
+                                      |metadata somePieceOfData = { name: "examples.hello", entryPoints: true }
+                                      |metadata other = { name: "examples.hello" }
+                                      |metadata noComma = { name: "examples.hello" entryPoints: true }
+                                      |metadata noComma = {
+                                      |name: "examples.hello"
+                                      |entryPoints: true
+                                      |}
+                                      |
+                                      |namespace examples.hello
+                                      |""".stripMargin)
+    assertEitherIsRight(result)
+  }
+
+  /*
+@readonly
+@http(method: "GET", uri: "/filmography/{actorId}")
+///Get the [Filmography] for the specified actor
+operation GetFilmography {
+  input: ActorInput,
+  output: Filmography
+}
+   */
+
+  test("operation") {
+    val result =
+      IdlParser.idlParser.parseAll(
+        """|$version: "2.0"
+           |
+           |namespace test
+           |
+           |operation GetFilmography {
+           |  input: ActorInput
+           |  output: Filmography
+           |}
+           |""".stripMargin
+      )
+    assert(result.isRight, s"Failed with ${result.swap.getOrElse(fail("err"))}")
+  }
+
+  test("map") {
+    val result =
+      IdlParser.idlParser.parseAll(
+        """|$version: "2.0"
+           |
+           |namespace test
+           |
+           |map Test {key: String value: String}
+           |""".stripMargin
+      )
+    assert(result.isRight, s"Failed with ${result.swap.getOrElse(fail("err"))}")
+  }
+
+  test("trait") {
+    val result =
+      IdlParser.idlParser.parseAll(
+        """|$version: "2.0"
+           |
+           |namespace test
+           |
+           |@http(method: "GET", uri: "/filmography/{actorId}")
+           |structure GetFilmography {
+           |  input: String,
+           |}
+           |""".stripMargin
+      )
+    assert(result.isRight, s"Failed with ${result.swap.getOrElse(fail("err"))}")
+  }
+
+  test("enum with commas") {
+    val result =
+      IdlParser.idlParser.parseAll(
+        """|$version: "2.0"
+           |
+           |namespace test
+           |
+           |enum OtherEnum {
+           |    V1 = "v1",
+           |    V2 = "v2"
+           |}
+           |""".stripMargin
+      )
+    assert(result.isRight, s"Failed with ${result.swap.getOrElse(fail("err"))}")
+  }
 }


### PR DESCRIPTION
In this commit, we diverge from the specification. I've commented on a similar issue that was resolved a few days ago. My hopes are that a similar resolution is applied and the divergence is no more.

In short, the grammar states that a value assignment should look like this:

`ValueAssignment = *SP "=" *SP NodeValue BR`

But this BR is counter-intuitive and probably what's intended is a `*WS` which is what this commits implements.

This fixes formatter issues with Enum and Structure which both can define ValueAssignment on their members