### PR TITLE
Fix the last issues I found on the parser

### DIFF
--- a/modules/formatter/src/ast/node.scala
+++ b/modules/formatter/src/ast/node.scala
@@ -21,9 +21,13 @@ import smithytranslate.formatter.ast.NodeValue.Number.{Exp, Frac}
 sealed trait NodeValue
 
 object NodeValue {
+  case class NodeArrayValue(
+      value: NodeValue,
+      ws0: Whitespace
+  )
   case class NodeArray(
       whitespace: Whitespace,
-      values: List[(NodeValue, Whitespace)]
+      values: List[NodeArrayValue]
   ) extends NodeValue
   case class NodeObject(
       whitespace: Whitespace,

--- a/modules/formatter/src/ast/shapes.scala
+++ b/modules/formatter/src/ast/shapes.scala
@@ -117,9 +117,11 @@ object shapes {
 
       case class ExplicitListMember(shapeId: ShapeId) extends ListMemberType
 
+      // Diverging from the grammer: https://smithy.io/2.0/spec/idl.html#grammar-token-smithy-ListMember
+      // The grammar says the members is mandatory, but it isnt
       case class ListMembers(
           ws0: Whitespace,
-          members: ListMember,
+          members: Option[ListMember],
           ws1: Whitespace
       )
 

--- a/modules/formatter/src/ast/shapes.scala
+++ b/modules/formatter/src/ast/shapes.scala
@@ -234,6 +234,9 @@ object shapes {
         nodeObject: NodeObject
     ) extends ShapeBody
 
+    case class InputShapeId(ws0: Whitespace, shapeId: ShapeId)
+    case class OutputShapeId(ws0: Whitespace, shapeId: ShapeId)
+
     case class InlineStructure(
         whitespace: Whitespace,
         traitStatements: TraitStatements,
@@ -252,13 +255,13 @@ object shapes {
 
     case class OperationInput(
         whitespace: Whitespace,
-        either: Either[InlineStructure, (Whitespace, ShapeId)],
+        either: Either[InlineStructure, InputShapeId],
         whitespace1: Whitespace
     ) extends OperationBodyPart
 
     case class OperationOutput(
         whitespace: Whitespace,
-        either: Either[InlineStructure, (Whitespace, ShapeId)],
+        either: Either[InlineStructure, OutputShapeId],
         whitespace1: Whitespace
     ) extends OperationBodyPart
 

--- a/modules/formatter/src/ast/shapes.scala
+++ b/modules/formatter/src/ast/shapes.scala
@@ -165,11 +165,13 @@ object shapes {
         case class ExplicitMapValue(shapeId: ShapeId) extends MapValueType
       }
 
+      // Diverging from the grammar: https://smithy.io/2.0/spec/idl.html#grammar-token-smithy-MapMembers
+      // The grammar says key member and value member are mandatory but they are not in practice
       case class MapMembers(
           ws0: Whitespace,
-          mapKey: MapKey,
+          mapKey: Option[MapKey],
           ws1: Whitespace,
-          mapValue: MapValue,
+          mapValue: Option[MapValue],
           ws2: Whitespace
       )
     }

--- a/modules/formatter/src/ast/shapes.scala
+++ b/modules/formatter/src/ast/shapes.scala
@@ -166,9 +166,9 @@ object shapes {
       case class MapMembers(
           ws0: Whitespace,
           mapKey: MapKey,
-          break: Whitespace,
+          ws1: Whitespace,
           mapValue: MapValue,
-          ws1: Whitespace
+          ws2: Whitespace
       )
     }
 

--- a/modules/formatter/src/ast/shapes.scala
+++ b/modules/formatter/src/ast/shapes.scala
@@ -244,30 +244,31 @@ object shapes {
 
     case class OperationBody(
         whitespace: Whitespace,
-        input: Option[OperationInput],
-        output: Option[OperationOutput],
-        errors: Option[OperationErrors],
+        bodyParts: List[OperationBodyPart],
         ws1: Whitespace
     )
+
+    sealed trait OperationBodyPart
 
     case class OperationInput(
         whitespace: Whitespace,
         either: Either[InlineStructure, (Whitespace, ShapeId)],
         whitespace1: Whitespace
-    )
+    ) extends OperationBodyPart
 
     case class OperationOutput(
         whitespace: Whitespace,
         either: Either[InlineStructure, (Whitespace, ShapeId)],
         whitespace1: Whitespace
-    )
+    ) extends OperationBodyPart
 
     case class OperationErrors(
         ws0: Whitespace,
         ws1: Whitespace,
         list: List[(Whitespace, Identifier)],
-        ws2: Whitespace
-    )
+        ws2: Whitespace,
+        ws3: Whitespace
+    ) extends OperationBodyPart
 
     case class OperationStatement(
         identifier: Identifier,

--- a/modules/formatter/src/ast/whitespace.scala
+++ b/modules/formatter/src/ast/whitespace.scala
@@ -36,3 +36,15 @@ object CommentType {
   type Line = Line.type
 }
 case class Comment(commentType: CommentType, text: String)
+
+object Comment {
+  def hasComment(br: Break): Boolean = br.comments.nonEmpty
+  def hasComment(whitespace: Whitespace): Boolean =
+    whitespace.comments.nonEmpty
+
+  def whitespacesHaveComments(whitespace: Seq[Whitespace]): Boolean =
+    whitespace.exists(hasComment)
+
+  def breaksHaveComments(breaks: Seq[Break]): Boolean =
+    breaks.exists(hasComment)
+}

--- a/modules/formatter/src/ast/whitespace.scala
+++ b/modules/formatter/src/ast/whitespace.scala
@@ -19,9 +19,9 @@ package ast
 import smithytranslate.formatter.ast.CommentType.{Documentation, Line}
 
 case object Comma {}
-case class Whitespace(whitespace: List[Comment])
+case class Whitespace(comments: List[Comment])
 
-case class Break(newLineOrComment: List[Comment])
+case class Break(comments: List[Comment])
 sealed trait CommentType { self =>
   def write: String = self match {
     case Line          => "//"

--- a/modules/formatter/src/parsers/NodeParser.scala
+++ b/modules/formatter/src/parsers/NodeParser.scala
@@ -97,7 +97,7 @@ object NodeParser {
     ) | identifier.map(NodeObjectKey.IdentifierNok)
 
   lazy val node_object_kvp: Parser[NodeObjectKeyValuePair] =
-    ((node_object_key ~ ws <* Parser.char(':')) ~ ws ~ node_value).map {
+    ((node_object_key ~ ws <* colon) ~ ws ~ node_value).map {
       case (((a, b), c), d) => NodeObjectKeyValuePair(a, b, c, d)
     }
 

--- a/modules/formatter/src/parsers/NodeParser.scala
+++ b/modules/formatter/src/parsers/NodeParser.scala
@@ -76,9 +76,9 @@ object NodeParser {
   val node_keywords: Parser[NodeKeyword] =
     Parser.stringIn(Set("true", "false", "null")).map(NodeKeyword)
 
-  val frac: Parser[Frac] = Parser.char('.') *> digit.string.map(Frac)
+  val frac: Parser[Frac] = Parser.char('.') *> digit.rep.string.map(Frac)
   val exp: Parser[Exp] =
-    (Parser.charWhere(c => c == 'e' || c == 'E') ~ opParser.? ~ digit.string)
+    (Parser.charIn('e', 'E') ~ opParser.? ~ digit.rep.string)
       .map { case ((a, b), c) =>
         Exp(a, b, c)
       }

--- a/modules/formatter/src/parsers/NodeParser.scala
+++ b/modules/formatter/src/parsers/NodeParser.scala
@@ -83,7 +83,7 @@ object NodeParser {
       }
 
   val number: Parser[SmithyNumber] =
-    (Parser.charWhere(_ == '-').?.with1 ~ nonNegativeIntString ~ frac.? ~ exp.?)
+    (Parser.charIn('-').?.with1 ~ nonNegativeIntString ~ frac.? ~ exp.?)
       .map { case (((a, b), c), d) =>
         SmithyNumber(a, b, c, d)
       }

--- a/modules/formatter/src/parsers/NodeParser.scala
+++ b/modules/formatter/src/parsers/NodeParser.scala
@@ -58,9 +58,10 @@ object NodeParser {
   val escaped_char: Parser[EscapedChar] =
     escape *> (Parser.charIn(escapeChars).map(CharCase) | unicode_escape)
   val QuotedChar: Parser[QuotedChar] =
-    qChar.backtrack.map(SimpleCharCase) | escaped_char.backtrack.map(
-      EscapedCharCase
-    ) | preserved_double.map(PreservedDoubleCase) | nl.as(NewLineCase)
+    qChar.backtrack.map(SimpleCharCase) |
+      escaped_char.backtrack.map(EscapedCharCase) |
+      preserved_double.map(PreservedDoubleCase) |
+      nl.as(NewLineCase)
 
   val ThreeDquotes = dquote ~ dquote ~ dquote
   val text_block: Parser[TextBlock] =

--- a/modules/formatter/src/parsers/NodeParser.scala
+++ b/modules/formatter/src/parsers/NodeParser.scala
@@ -108,11 +108,13 @@ object NodeParser {
         NodeObject(whitespace, maybeTuple)
       }
 
-  val nodeArray: Parser[NodeArray] =
-    ((openSquare *> ws ~ (node_value ~ ws).backtrack.rep0) <* (ws ~ closeSquare))
+  val nodeArray: Parser[NodeArray] = {
+    val valueP = (node_value ~ ws).map(NodeArrayValue.tupled)
+    ((openSquare *> ws ~ valueP.backtrack.rep0) <* (ws ~ closeSquare))
       .map { case (whitespace, maybeTuple) =>
         NodeArray(whitespace, maybeTuple)
       }
+  }
 }
 
 /*

--- a/modules/formatter/src/parsers/ShapeIdParser.scala
+++ b/modules/formatter/src/parsers/ShapeIdParser.scala
@@ -31,9 +31,9 @@ import cats.parse.Parser
 import cats.parse.Rfc5234.{alpha, digit}
 
 object ShapeIdParser {
-  val underscore: Parser[Underscore] = Parser.charWhere(_ == '_').as(Underscore)
+  val underscore: Parser[Underscore] = Parser.charIn('_').as(Underscore)
   val identifier_chars: Parser[IdentifierChar] =
-    (Parser.charWhere(_ == '_') | digit | alpha).map(IdentifierChar)
+    (Parser.charIn('_') | digit | alpha).map(IdentifierChar)
   val identifier_start: Parser[IdentifierStart] =
     (underscore.rep0.with1 ~ alpha).map(IdentifierStart.tupled)
   val identifier: Parser[Identifier] =
@@ -41,7 +41,7 @@ object ShapeIdParser {
   val shape_id_member: Parser[ShapeIdMember] =
     (Parser.char('$') *> identifier).map(ShapeIdMember)
   val namespace: Parser[Namespace] =
-    (identifier ~ (Parser.charWhere(_.==('.')) *> identifier).rep0)
+    (identifier ~ (Parser.charIn('.') *> identifier).rep0)
       .map(Namespace.tupled)
   val absolute_root_shape_id: Parser[AbsoluteRootShapeId] =
     ((namespace <* Parser.char('#')) ~ identifier)

--- a/modules/formatter/src/parsers/ShapeParser.scala
+++ b/modules/formatter/src/parsers/ShapeParser.scala
@@ -87,8 +87,9 @@ object ShapeParser {
 
   // see comments on ValueAssignment
   val value_assigments: Parser[ValueAssignment] =
-    (sp *> Parser.char('=') *> sp *> node_value ~ ws).map { case (l, r) =>
-      ValueAssignment(l, r)
+    (sp0.with1 *> Parser.char('=') *> sp0 *> node_value ~ ws).map {
+      case (l, r) =>
+        ValueAssignment(l, r)
     }
 
   val mixins: Parser[Mixin] =

--- a/modules/formatter/src/parsers/ShapeParser.scala
+++ b/modules/formatter/src/parsers/ShapeParser.scala
@@ -251,18 +251,22 @@ object ShapeParser {
 
   object operation_parsers {
     val ir: Parser[(Whitespace, ShapeId)] = colon *> ws ~ shape_id
-    val operation_input: Parser[OperationInput] =
-      (Parser.string("input") *> ws ~ ir.backtrack.eitherOr(
+    val operation_input: Parser[OperationInput] = {
+      val isid = ir.map { case (ws, id) => InputShapeId(ws, id) }
+      (Parser.string("input") *> ws ~ isid.backtrack.eitherOr(
         inline_structure
       ) ~ ws).map { case ((ws0, either), ws1) =>
         OperationInput(ws0, either, ws1)
       }
-    val operation_output: Parser[OperationOutput] =
-      (Parser.string("output") *> ws ~ ir.backtrack.eitherOr(
+    }
+    val operation_output: Parser[OperationOutput] = {
+      val osid = ir.map { case (ws, id) => OutputShapeId(ws, id) }
+      (Parser.string("output") *> ws ~ osid.backtrack.eitherOr(
         inline_structure
       ) ~ ws).map { case ((ws0, either), ws1) =>
         OperationOutput(ws0, either, ws1)
       }
+    }
     val operation_errors: Parser[OperationErrors] =
       ((((Parser.string("errors") *> ws <* Parser.char(
         ':'

--- a/modules/formatter/src/parsers/ShapeParser.scala
+++ b/modules/formatter/src/parsers/ShapeParser.scala
@@ -94,7 +94,7 @@ object ShapeParser {
   val mixins: Parser[Mixin] =
     ((sp.with1 *> Parser.string(
       "with"
-    ) *> ws <* openSquare) ~ (ws.with1 ~ shape_id).rep ~ ws <* closeSquare)
+    ) *> ws <* openSquare) ~ (ws.with1 ~ shape_id).backtrack.rep ~ ws <* closeSquare)
       .map { case ((ws0, values), ws1) =>
         Mixin(ws0, values, ws1)
       }

--- a/modules/formatter/src/parsers/ShapeParser.scala
+++ b/modules/formatter/src/parsers/ShapeParser.scala
@@ -94,7 +94,7 @@ object ShapeParser {
     }
 
   val mixins: Parser[Mixin] =
-    ((sp.with1 *> Parser.string(
+    ((sp0.with1 *> Parser.string(
       "with"
     ) *> ws <* openSquare) ~ (ws.with1 ~ shape_id).backtrack.rep ~ ws <* closeSquare)
       .map { case ((ws0, values), ws1) =>

--- a/modules/formatter/src/parsers/ShapeParser.scala
+++ b/modules/formatter/src/parsers/ShapeParser.scala
@@ -109,7 +109,7 @@ object ShapeParser {
     }
 
   val enum_shape_members: Parser[EnumShapeMembers] =
-    (openCurly *> ws.with1 ~ (trait_statements.with1 ~ identifier ~ value_assigments.? ~ ws).rep <* closeCurly)
+    (openCurly *> ws.with1 ~ (trait_statements.with1 ~ identifier ~ value_assigments.backtrack.? ~ ws).rep <* closeCurly)
       .map { case (ws, members) =>
         EnumShapeMembers(
           ws,

--- a/modules/formatter/src/parsers/ShapeParser.scala
+++ b/modules/formatter/src/parsers/ShapeParser.scala
@@ -52,6 +52,7 @@ import smithytranslate.formatter.parsers.WhitespaceParser.{br, sp, sp0, ws}
 import smithytranslate.formatter.parsers.NodeParser._
 import smithytranslate.formatter.parsers.ShapeIdParser._
 import smithytranslate.formatter.parsers.ShapeParser.list_parsers.list_statement
+import smithytranslate.formatter.parsers.ShapeParser.set_parsers.set_statement
 import smithytranslate.formatter.parsers.ShapeParser.map_parsers.map_statement
 import smithytranslate.formatter.parsers.ShapeParser.operation_parsers.operation_statement
 import smithytranslate.formatter.parsers.ShapeParser.structure_parsers.structure_statement
@@ -148,13 +149,23 @@ object ShapeParser {
         case ((ws0, members), ws1) => ListMembers(ws0, members, ws1)
       }
 
-    val list_statement: Parser[ListStatement] =
+    private[parsers] def list_statement0(
+        lookingFor: String
+    ): Parser[ListStatement] =
       ((Parser.string(
-        "list"
+        lookingFor
       ) <* sp0) *> identifier ~ mixinBT.? ~ ws ~ list_members).map {
         case (((id, mixin), ws), members) =>
           ListStatement(id, mixin, ws, members)
       }
+
+    val list_statement: Parser[ListStatement] = list_statement0("list")
+  }
+
+  object set_parsers {
+    // relying on list_parsers
+    import list_parsers.list_statement0
+    val set_statement: Parser[ListStatement] = list_statement0("set")
   }
 
   object map_parsers {
@@ -326,7 +337,7 @@ object ShapeParser {
       }
 
   val shape_body: Parser[shapes.ShapeBody] =
-    simple_shape_statement | enum_shape_statement | list_statement | map_statement | structure_statement | union_statement | service_statement | operation_statement | resource_statement
+    simple_shape_statement | enum_shape_statement | list_statement | set_statement | map_statement | structure_statement | union_statement | service_statement | operation_statement | resource_statement
   val shape_statement: Parser[ShapeStatement] = {
     val traitAndBody = trait_statements.with1 ~ shape_body
     val interspersedBr =

--- a/modules/formatter/src/parsers/ShapeParser.scala
+++ b/modules/formatter/src/parsers/ShapeParser.scala
@@ -129,7 +129,7 @@ object ShapeParser {
   object list_parsers {
 
     val explicit_list_member: Parser[ExplicitListMember] =
-      Parser.string("member") *> sp.rep0 *> Parser.string(":") *> sp *> shape_id
+      Parser.string("member") *> sp0 *> Parser.string(":") *> sp0 *> shape_id
         .map(
           ExplicitListMember
         )

--- a/modules/formatter/src/parsers/ShapeParser.scala
+++ b/modules/formatter/src/parsers/ShapeParser.scala
@@ -182,10 +182,10 @@ object ShapeParser {
         }
 
     val map_members =
-      (openCurly *> (ws ~ map_key ~ ws ~ map_value ~ ws) <* closeCurly).map {
-        case ((((ws0, key), ws1), value), ws2) =>
+      (openCurly *> (ws ~ map_key.? ~ ws ~ map_value.? ~ ws) <* closeCurly)
+        .map { case ((((ws0, key), ws1), value), ws2) =>
           MapMembers(ws0, key, ws1, value, ws2)
-      }
+        }
     val map_statement: Parser[MapStatement] =
       (Parser.string("map") *> sp0 *> identifier ~ mixinBT.? ~ ws ~ map_members)
         .map { case (((id, mixins), ws), members) =>

--- a/modules/formatter/src/parsers/ShapeParser.scala
+++ b/modules/formatter/src/parsers/ShapeParser.scala
@@ -183,8 +183,8 @@ object ShapeParser {
 
     val map_members =
       (openCurly *> (ws ~ map_key ~ ws ~ map_value ~ ws) <* closeCurly).map {
-        case ((((ws0, key), br), value), ws2) =>
-          MapMembers(ws0, key, br, value, ws2)
+        case ((((ws0, key), ws1), value), ws2) =>
+          MapMembers(ws0, key, ws1, value, ws2)
       }
     val map_statement: Parser[MapStatement] =
       (Parser.string("map") *> sp0 *> identifier ~ mixinBT.? ~ ws ~ map_members)

--- a/modules/formatter/src/parsers/ShapeParser.scala
+++ b/modules/formatter/src/parsers/ShapeParser.scala
@@ -199,7 +199,7 @@ object ShapeParser {
     val elided_structure_member: Parser[ElidedStructureMember] =
       (Parser.string("$") *> identifier).map(ElidedStructureMember)
     val structure_member: Parser[StructureMember] = {
-      ((explicit_structure_member.backtrack | elided_structure_member) ~ value_assigments.?)
+      ((explicit_structure_member.backtrack | elided_structure_member) ~ value_assigments.backtrack.?)
         .map { case (member, va) =>
           StructureMember(member, va)
         }

--- a/modules/formatter/src/parsers/ShapeParser.scala
+++ b/modules/formatter/src/parsers/ShapeParser.scala
@@ -160,13 +160,13 @@ object ShapeParser {
     val elided_map_key: Parser[ElidedMapKey] =
       shape_id_member.map(ElidedMapKey)
     val explicit_map_key: Parser[ExplicitMapKey] =
-      Parser.string("key") *> sp0 *> Parser.char(':') *> sp0 *> shape_id.map(
+      Parser.string("key") *> sp0 *> colon *> sp0 *> shape_id.map(
         ExplicitMapKey
       )
     val elided_map_value: Parser[ElidedMapValue] =
       shape_id_member.map(ElidedMapValue)
     val explicit_map_value: Parser[ExplicitMapValue] =
-      Parser.string("value") *> sp0 *> Parser.char(':') *> sp0 *> shape_id.map(
+      Parser.string("value") *> sp0 *> colon *> sp0 *> shape_id.map(
         ExplicitMapValue
       )
     val map_value: Parser[MapValue] =
@@ -249,7 +249,7 @@ object ShapeParser {
   }
 
   object operation_parsers {
-    val ir: Parser[(Whitespace, ShapeId)] = Parser.char(':') *> ws ~ shape_id
+    val ir: Parser[(Whitespace, ShapeId)] = colon *> ws ~ shape_id
     val operation_input: Parser[OperationInput] =
       (Parser.string("input") *> ws ~ ir.backtrack.eitherOr(
         inline_structure

--- a/modules/formatter/src/parsers/ShapeParser.scala
+++ b/modules/formatter/src/parsers/ShapeParser.scala
@@ -129,7 +129,7 @@ object ShapeParser {
   object list_parsers {
 
     val explicit_list_member: Parser[ExplicitListMember] =
-      Parser.string("member") *> sp0 *> Parser.string(":") *> sp0 *> shape_id
+      Parser.string("member") *> sp0 *> Parser.charIn(':') *> sp0 *> shape_id
         .map(
           ExplicitListMember
         )
@@ -195,10 +195,10 @@ object ShapeParser {
 
   object structure_parsers {
     val explicit_structure_member: Parser[ExplicitStructureMember] =
-      ((identifier <* sp0 <* Parser.string(":") <* sp0) ~ shape_id)
+      ((identifier <* sp0 <* Parser.charIn(':') <* sp0) ~ shape_id)
         .map(ExplicitStructureMember.tupled)
     val elided_structure_member: Parser[ElidedStructureMember] =
-      (Parser.string("$") *> identifier).map(ElidedStructureMember)
+      (Parser.charIn('$') *> identifier).map(ElidedStructureMember)
     val structure_member: Parser[StructureMember] = {
       ((explicit_structure_member.backtrack | elided_structure_member) ~ value_assigments.backtrack.?)
         .map { case (member, va) =>

--- a/modules/formatter/src/parsers/ShapeParser.scala
+++ b/modules/formatter/src/parsers/ShapeParser.scala
@@ -144,7 +144,7 @@ object ShapeParser {
         }
 
     val list_members: Parser[ListMembers] =
-      (openCurly *> ws ~ list_member ~ ws <* closeCurly).map {
+      (openCurly *> ws ~ list_member.? ~ ws <* closeCurly).map {
         case ((ws0, members), ws1) => ListMembers(ws0, members, ws1)
       }
 

--- a/modules/formatter/src/parsers/SmithyTraitParser.scala
+++ b/modules/formatter/src/parsers/SmithyTraitParser.scala
@@ -33,7 +33,7 @@ object SmithyTraitParser {
 
   //    node_object_key ws ":" ws node_value
   val trait_structure_kvp: Parser[TraitStructureKeyValuePair] =
-    ((node_object_key ~ ws <* Parser.char(':')) ~ ws ~ node_value).map {
+    ((node_object_key ~ ws <* colon) ~ ws ~ node_value).map {
       case (((a, b), c), d) => TraitStructureKeyValuePair(a, b, c, d)
     }
   //       TraitStructureKvp *(*WS TraitStructureKvp)

--- a/modules/formatter/src/parsers/WhitespaceParser.scala
+++ b/modules/formatter/src/parsers/WhitespaceParser.scala
@@ -40,7 +40,7 @@ object WhitespaceParser {
   val commentType: Parser[CommentType] =
     documentation_comment.backtrack | line_comment
   val comment: Parser[Comment] =
-    (commentType ~ not_newline <* nl).map(Comment.tupled)
+    (commentType ~ not_newline <* nl).map(Comment.apply.tupled)
   private val commentOrNewline: Parser[Option[Comment]] =
     comment.eitherOr(nl).map(_.toOption)
 

--- a/modules/formatter/src/parsers/WhitespaceParser.scala
+++ b/modules/formatter/src/parsers/WhitespaceParser.scala
@@ -32,7 +32,8 @@ object WhitespaceParser {
     Parser
       .defer(sp.rep0.with1 *> commentOrNewline.rep <* ws)
       .map(list => Break(list.toList.flatten))
-  private val not_newline: Parser0[String] = Parser.until(nl)
+  private val not_newline: Parser0[String] =
+    Parser.until(nl).?.map(_.getOrElse(""))
   val line_comment: Parser[Line] = Parser.string("//").as(Line)
   val documentation_comment: Parser[CommentType.Documentation] =
     Parser.string("///").as(Documentation)

--- a/modules/formatter/src/parsers/package.scala
+++ b/modules/formatter/src/parsers/package.scala
@@ -21,6 +21,7 @@ package object parsers {
   val openCurly: Parser[Unit] = Parser.char('{')
   val closeCurly: Parser[Unit] = Parser.char('}')
   val openSquare: Parser[Unit] = Parser.char('[')
+  val colon: Parser[Unit] = Parser.char(':')
   val closeSquare: Parser[Unit] = Parser.char(']')
   val escapeChars: List[Char] =
     List('\\', '"', '\'', 'b', 'f', 'n', 'r', 't', '/')

--- a/modules/formatter/src/util/string_ops.scala
+++ b/modules/formatter/src/util/string_ops.scala
@@ -112,7 +112,7 @@ object string_ops {
 
   def indent(value: String, delimiter: String, indentLevel: Int): String = {
     val indentation = " " * indentLevel
-    val intermediate = value
+    value
       .split(delimiter, -1)
       .toList
       .filterNot(_.isEmpty)
@@ -121,14 +121,6 @@ object string_ops {
         else (acc + delimiter + indentation + line, isFirst)
       }
       ._1
-    if (
-      (intermediate.trim.startsWith("[") || intermediate.trim.startsWith(
-        "{"
-      )) && intermediate.length < 80
-    )
-      intermediate.replaceAll(" ", "").replaceAll("\n", " ")
-    else
-      intermediate
   }
 
   def simpleIndent(spaces: Int, skipfirst: Boolean, str: String): String = {

--- a/modules/formatter/src/util/string_ops.scala
+++ b/modules/formatter/src/util/string_ops.scala
@@ -154,12 +154,9 @@ object string_ops {
       newLineAfterOpen: Boolean = true,
       newLineBeforeClose: Boolean = true
   ): String = {
-    if (s.startsWith("{")) s
-    else {
-      val open = if (newLineAfterOpen) "\n{" else "{"
-      val close = if (newLineBeforeClose) "\n}" else "}"
-      open + s + close
-    }
+    val open = if (newLineAfterOpen) "{\n" else "{"
+    val close = if (newLineBeforeClose) "\n}" else "}"
+    open + s + close
   }
 
   def indentIfNotEmpty(value: String): String = {

--- a/modules/formatter/src/util/string_ops.scala
+++ b/modules/formatter/src/util/string_ops.scala
@@ -86,6 +86,9 @@ object string_ops {
       string
   }
 
+  def isTooWide[A](values: List[A], limit: Integer = 3): Boolean =
+    values.size >= limit
+
   def indentList[A: Show](
       value: List[A],
       delimiter: String,

--- a/modules/formatter/src/util/string_ops.scala
+++ b/modules/formatter/src/util/string_ops.scala
@@ -130,24 +130,6 @@ object string_ops {
     val indent = " " * spaces
     str.split("\n").mkString(if (skipfirst) "" else indent, s"\n$indent", "")
   }
-  def formatEnum(string: String): String = {
-    simpleIndent(
-      4,
-      skipfirst = true,
-      string
-        .replaceAll(" +", " ")
-        .replaceAll("\n", "")
-        .split("},", -1)
-        .mkString("},\n")
-        .split("\\[")
-        .mkString("[\n")
-    )
-      .insertBeforeLast(']', "\n")
-  }
-
-  def formatStructure(string: String): String = {
-    string.split(",").mkString(",\n")
-  }
 
   def addBrackets(
       s: String,

--- a/modules/formatter/src/writer/NodeWriter.scala
+++ b/modules/formatter/src/writer/NodeWriter.scala
@@ -70,21 +70,24 @@ object NodeWriter {
     }
 
   implicit val nodeObjectWriter: Writer[NodeObject] = Writer.write {
-    case NodeObject(ws, None)               => s"{${ws.write}}"
-    case NodeObject(ws, Some((nokvp, Nil))) => s"{${ws.write}${nokvp.write}}"
+    case NodeObject(ws, None) => addBrackets(s"${ws.write}")
+    case NodeObject(ws, Some((nokvp, Nil))) =>
+      addBrackets(indent(s"${ws.write}${nokvp.write}", "\n", 4))
     case NodeObject(ws, Some((nokvp, rest))) =>
-      ws.write + indent(
-        s"${ws.write}${nokvp.write}${rest.map { case (ws, kvp) =>
-            s",\n${ws.write}${kvp.write}"
-          }.mkString}",
-        "\n",
-        4
+      addBrackets(
+        ws.write + indent(
+          s"${ws.write}${nokvp.write}${rest.map { case (ws, kvp) =>
+              s",\n${ws.write}${kvp.write}"
+            }.mkString}",
+          "\n",
+          4
+        )
       )
   }
 
   implicit val nodeValueWriter: Writer[NodeValue] = Writer.write {
     case array: NodeArray       => array.write
-    case nodeObject: NodeObject => addBrackets(nodeObject.write)
+    case nodeObject: NodeObject => nodeObject.write
     case number: SmithyNumber   => smithyNumberWriter(number)
     case NodeKeyword(value)     => value
     case value: NodeStringValue =>

--- a/modules/formatter/src/writer/NodeWriter.scala
+++ b/modules/formatter/src/writer/NodeWriter.scala
@@ -120,7 +120,7 @@ object NodeWriter {
     case SimpleCharCase(char)                 => s"${char.write}"
     case EscapedCharCase(escapedChar)         => escapedChar.write
     case PreservedDoubleCase(preservedDouble) => preservedDouble.write
-    case NewLineCase                          => "\\n"
+    case NewLineCase                          => "\n"
   }
   implicit val quotedTextWriter: Writer[QuotedText] = Writer.write {
     case QuotedText(text) =>
@@ -128,7 +128,7 @@ object NodeWriter {
   }
   implicit val textBlockWriter: Writer[TextBlock] = Writer.write {
     case TextBlock(text) =>
-      s"\"\"\"${text.writeN}\"\"\""
+      s"\"\"\"\n${text.writeN}\"\"\""
   }
   implicit val fracWriter: Writer[Frac] = Writer.write { case Frac(frac) =>
     s".${frac.write}"

--- a/modules/formatter/src/writer/NodeWriter.scala
+++ b/modules/formatter/src/writer/NodeWriter.scala
@@ -70,7 +70,7 @@ object NodeWriter {
     }
 
   implicit val nodeObjectWriter: Writer[NodeObject] = Writer.write {
-    case NodeObject(ws, None) => addBrackets(s"${ws.write}")
+    case NodeObject(ws, None) => addBrackets(ws.write)
     case NodeObject(ws, Some((nokvp, Nil))) =>
       addBrackets(indent(s"${ws.write}${nokvp.write}", "\n", 4))
     case NodeObject(ws, Some((nokvp, rest))) =>

--- a/modules/formatter/src/writer/NodeWriter.scala
+++ b/modules/formatter/src/writer/NodeWriter.scala
@@ -103,8 +103,11 @@ object NodeWriter {
   }
 
   def smithyNumberWriter(number: SmithyNumber): String = {
-    s"${number.minus.getOrElse("")}${number.smithyInt.write}${number.frac
-        .getOrElse("")}${number.exp.getOrElse("")}"
+    val sign = number.minus.map(_.toString).getOrElse("")
+    val int = number.smithyInt.write
+    val frac = number.frac.map(_.write).getOrElse("")
+    val exp = number.exp.map(_.write).getOrElse("")
+    s"$sign$int${frac}${exp}"
   }
 
   implicit val nodeObjectKeyWriter: Writer[NodeObjectKey] = Writer.write {

--- a/modules/formatter/src/writer/ShapeWriter.scala
+++ b/modules/formatter/src/writer/ShapeWriter.scala
@@ -99,11 +99,11 @@ object ShapeWriter {
       s" with${whitespace.write} $values"
   }
   implicit val mapMemberTypeWriter: Writer[MapKeyType] = Writer.write {
-    case ElidedMapKey(member)    => s"$$${member.write}"
-    case ExplicitMapKey(shapeId) => s"key: ${shapeId.write}"
+    case ElidedMapKey(shapeIdMember) => shapeIdMember.write
+    case ExplicitMapKey(shapeId)     => s"key: ${shapeId.write}"
   }
   implicit val mapValueTypeWriter: Writer[MapValueType] = Writer.write {
-    case ElidedMapValue(member)    => s"$$${member.write}"
+    case ElidedMapValue(member)    => s"${member.write}"
     case ExplicitMapValue(shapeId) => s"value: ${shapeId.write}"
   }
   implicit val mapKeyWriter: Writer[MapKey] = Writer.write {
@@ -223,8 +223,8 @@ object ShapeWriter {
       s"${whitespace.write}${lines}${ws1.write}"
   }
   implicit val listMemberTypeWriter: Writer[ListMemberType] = Writer.write {
-    case ElidedListMember(shapeIdMember) => s"$$${shapeIdMember.write}"
-    case ExplicitListMember(shapeId)     => s"    member: ${shapeId.write}"
+    case ElidedListMember(shapeIdMember) => shapeIdMember.write
+    case ExplicitListMember(shapeId)     => s"member: ${shapeId.write}"
   }
   implicit val listMemberWriter: Writer[ListMember] = Writer.write {
     case ListMember(traitStatements, listMemberType) =>
@@ -262,7 +262,7 @@ object ShapeWriter {
     case OperationStatement(identifier, mixin, whitespace, operationBody) =>
       s"operation ${identifier.write} ${mixin.write}${whitespace.write}{\n${indent(operationBody.write, "\n", 4)}\n}"
     case ListStatement(identifier, mixin, whitespace, members) =>
-      s"list ${identifier.write}${mixin.write}${whitespace.write} {\n${members.write}\n}"
+      s"list ${identifier.write}${mixin.write}${whitespace.write} {\n${indent(members.write, "\n", 4)}\n}"
     case StructureStatement(
           identifier,
           resource,

--- a/modules/formatter/src/writer/ShapeWriter.scala
+++ b/modules/formatter/src/writer/ShapeWriter.scala
@@ -202,15 +202,18 @@ object ShapeWriter {
       val comments = list.map(_._1)
       val useNewLine =
         Comment.whitespacesHaveComments(comments) || isTooWide(list)
-      val values = if (useNewLine) {
-        list
-          .map(_.write)
-          .map(indent(_, "\n", 4))
-          .mkString_(s"[\n", "\n", "\n]")
-      } else {
-        // no comment, just print the value
-        list.map(_._2.write).mkString_(s"[", ", ", "]")
-      }
+      val values =
+        if (list.isEmpty) {
+          "[]"
+        } else if (useNewLine) {
+          list
+            .map(_.write)
+            .map(indent(_, "\n", 4))
+            .mkString(s"[\n", "\n", "\n]")
+        } else {
+          // no comment, just print the value
+          list.map(_._2.write).mkString_(s"[", ", ", "]")
+        }
       s"errors${ws0.write}: ${ws1.write}${values}${ws3.write}"
   }
   implicit val operationBodyPart: Writer[OperationBodyPart] = Writer.write {

--- a/modules/formatter/src/writer/ShapeWriter.scala
+++ b/modules/formatter/src/writer/ShapeWriter.scala
@@ -180,9 +180,13 @@ object ShapeWriter {
   }
 
   implicit val inlineStructureWriter: Writer[InlineStructure] = Writer.write {
-    case InlineStructure(whitespace, traitStatements, mixin, ws1, members) =>
+    case InlineStructure(whitespace, traitStatements, _mixin, ws1, members) =>
       val indented = indent(members.write, "\n", 4)
-      s" := {\n${whitespace.write}${traitStatements.write}${mixin.write}${ws1.write}${indented}\n}"
+      val blank =
+        if (traitStatements.list.nonEmpty) " "
+        else ""
+      val mixin = _mixin.map(_.write + " ").getOrElse(" ")
+      s" :=${whitespace.write}${blank}${traitStatements.write}${mixin}{\n${ws1.write}${indented}\n}"
   }
   implicit val operationInputWriter: Writer[OperationInput] = Writer.write {
     case OperationInput(ws0, members, ws1) =>

--- a/modules/formatter/src/writer/ShapeWriter.scala
+++ b/modules/formatter/src/writer/ShapeWriter.scala
@@ -168,18 +168,29 @@ object ShapeWriter {
         .mkString_("", ",\n", "")
       s"${whitespace.write}${memberLines}"
   }
+
+  implicit val inputShapeIdWriter: Writer[InputShapeId] = Writer.write {
+    case InputShapeId(ws0, shapeId) =>
+      s": ${ws0.write}${shapeId.write}"
+  }
+
+  implicit val outputShapeIdWriter: Writer[OutputShapeId] = Writer.write { os =>
+    inputShapeIdWriter.write(InputShapeId(os.ws0, os.shapeId))
+  }
+
   implicit val inlineStructureWriter: Writer[InlineStructure] = Writer.write {
     case InlineStructure(whitespace, traitStatements, mixin, ws1, members) =>
-      s"${whitespace.write}${traitStatements.write}${mixin.write}${ws1.write}${members.write}"
+      val indented = indent(members.write, "\n", 4)
+      s" := {\n${whitespace.write}${traitStatements.write}${mixin.write}${ws1.write}${indented}\n}"
   }
   implicit val operationInputWriter: Writer[OperationInput] = Writer.write {
     case OperationInput(ws0, members, ws1) =>
-      s"input: ${ws0.write}${members.write}${ws1.write}"
+      s"input${ws0.write}${members.write}${ws1.write}"
   }
 
   implicit val operationOutputWriter: Writer[OperationOutput] = Writer.write {
     case OperationOutput(ws0, members, ws1) =>
-      s"output: ${ws0.write}${members.write}${ws1.write}"
+      s"output${ws0.write}${members.write}${ws1.write}"
   }
   implicit val operationErrorsWriter: Writer[OperationErrors] = Writer.write {
     case OperationErrors(ws0, ws1, list, _, ws3) =>
@@ -241,7 +252,7 @@ object ShapeWriter {
     case ResourceStatement(identifier, mixin, whitespace, nodeObject) =>
       s"resource ${identifier.write} ${mixin.write}${whitespace.write} {\n${nodeObject.write}\n}"
     case OperationStatement(identifier, mixin, whitespace, operationBody) =>
-      s"operation ${identifier.write} ${mixin.write}${whitespace.write} {\n${indent(operationBody.write, "\n", 4)}\n}"
+      s"operation ${identifier.write} ${mixin.write}${whitespace.write}{\n${indent(operationBody.write, "\n", 4)}\n}"
     case ListStatement(identifier, mixin, whitespace, members) =>
       s"list ${identifier.write}${mixin.write}${whitespace.write} {\n${members.write}\n}"
     case StructureStatement(

--- a/modules/formatter/src/writer/ShapeWriter.scala
+++ b/modules/formatter/src/writer/ShapeWriter.scala
@@ -33,7 +33,7 @@ import ast.shapes.ShapeBody.StructureMembers.{
   StructureMember,
   StructureMemberType
 }
-import util.string_ops.{indent, suffix, isTooWide}
+import util.string_ops.{indent, isTooWide}
 import NodeWriter.{nodeObjectWriter, nodeValueWriter}
 import ShapeIdWriter.{
   absoluteRootShapeIdWriter,
@@ -161,12 +161,11 @@ object ShapeWriter {
   }
   implicit val structureMembersWriter: Writer[StructureMembers] = Writer.write {
     case StructureMembers(whitespace, members) =>
-      val memberLines = members
-        .map { case (traitStatements, structureMember, ws) =>
-          s"${traitStatements.write}${structureMember.write}${ws.write}"
-        }
-        .mkString_("", ",\n", "")
-      s"${whitespace.write}${memberLines}"
+      val memberLines = members.map {
+        case (traitStatements, structureMember, ws) =>
+          s"${traitStatements.write}${structureMember.write},\n${ws.write}"
+      }.mkString
+      indent(s"${whitespace.write}${memberLines}", "\n", 4)
   }
 
   implicit val inputShapeIdWriter: Writer[InputShapeId] = Writer.write {
@@ -180,8 +179,7 @@ object ShapeWriter {
 
   implicit val inlineStructureWriter: Writer[InlineStructure] = Writer.write {
     case InlineStructure(whitespace, traitStatements, mixin, ws1, members) =>
-      val indented = indent(members.write, "\n", 4)
-      s" := {\n${whitespace.write}${traitStatements.write}${mixin.write}${ws1.write}${indented}\n}"
+      s" := {\n${whitespace.write}${traitStatements.write}${mixin.write}${ws1.write}${members.write}\n}"
   }
   implicit val operationInputWriter: Writer[OperationInput] = Writer.write {
     case OperationInput(ws0, members, ws1) =>
@@ -262,7 +260,7 @@ object ShapeWriter {
           whitespace,
           members
         ) =>
-      s"structure ${identifier.write}${resource.write}${mixins.write}${whitespace.write} {\n${indent(suffix(members.write, "\n"), "\n", 4)}\n}"
+      s"structure ${identifier.write}${resource.write}${mixins.write}${whitespace.write} {\n${members.write}\n}"
 
   }
 

--- a/modules/formatter/src/writer/ShapeWriter.scala
+++ b/modules/formatter/src/writer/ShapeWriter.scala
@@ -171,7 +171,7 @@ object ShapeWriter {
       s"output: ${ws0.write}${members.write}${ws1.write}"
   }
   implicit val operationErrorsWriter: Writer[OperationErrors] = Writer.write {
-    case OperationErrors(ws0, ws1, list, ws3) =>
+    case OperationErrors(ws0, ws1, list, _, ws3) =>
       val listLine = list
         .map { case (ws, shapeId) =>
           s"${ws.write}${shapeId.write}"
@@ -179,9 +179,15 @@ object ShapeWriter {
         .mkString_("[", ", ", ",]")
       s"errors: ${ws0.write}${ws1.write}${listLine}${ws3.write}"
   }
+  implicit val operationBodyPart: Writer[OperationBodyPart] = Writer.write {
+    case i: OperationInput  => i.write
+    case o: OperationOutput => o.write
+    case e: OperationErrors => e.write
+  }
   implicit val operationBodyWriter: Writer[OperationBody] = Writer.write {
-    case OperationBody(whitespace, input, output, errors, ws1) =>
-      val lines = List(input.write, output.write, errors.write)
+    case OperationBody(whitespace, bodyParts, ws1) =>
+      val lines = bodyParts
+        .map(_.write)
         .filter(_.nonEmpty)
         .mkString_("", "\n", "")
       s"${whitespace.write}${lines}${ws1.write}"

--- a/modules/formatter/src/writer/ShapeWriter.scala
+++ b/modules/formatter/src/writer/ShapeWriter.scala
@@ -105,8 +105,8 @@ object ShapeWriter {
   }
 
   implicit val mapMembersWriter: Writer[MapMembers] = Writer.write {
-    case MapMembers(ws0, mapKey, break, mapValue, ws1) =>
-      s"${ws0.write}${mapKey.write}${break.write}${mapValue.write}${ws1.write}"
+    case MapMembers(ws0, mapKey, ws1, mapValue, ws2) =>
+      s"${ws0.write}${mapKey.write}\n${ws1.write}${mapValue.write}${ws2.write}"
   }
 
   implicit val valueAssignmentWriter: Writer[ValueAssignment] = Writer.write {
@@ -222,7 +222,7 @@ object ShapeWriter {
       s"$typeName ${id.write}${mixin.write}${whitespace.write} {\n${indent(enumShapeMembers.write, "\n", 4)}\n}"
 
     case MapStatement(identifier, mixin, whitespace, members) =>
-      s"map ${identifier.write}${mixin.write}${whitespace.write} {\n${members.write}\n}"
+      s"map ${identifier.write}${mixin.write}${whitespace.write} {\n${indent(members.write, "\n", 4)}\n}"
     case UnionStatement(identifier, mixin, whitespace, members) =>
       s"union ${identifier.write}${mixin.write}${whitespace.write} {\n${indent(members.write, "\n", 4)}\n}"
     case ServiceStatement(identifier, mixin, whitespace1, nodeObject) =>

--- a/modules/formatter/src/writer/ShapeWriter.scala
+++ b/modules/formatter/src/writer/ShapeWriter.scala
@@ -148,12 +148,11 @@ object ShapeWriter {
 
   implicit val unionMembersWriter: Writer[UnionMembers] = Writer.write {
     case UnionMembers(whitespace, members) =>
-      val memberLines = members
-        .map { case (traitStatements, structureMember, ws) =>
-          s"${traitStatements.write}${structureMember.write}${ws.write}"
-        }
-        .mkString_("", ",\n", ",")
-      s"${whitespace.write}${memberLines}"
+      val memberLines = members.map {
+        case (traitStatements, structureMember, ws) =>
+          s"${traitStatements.write}${structureMember.write}\n${ws.write}"
+      }.mkString
+      indent(s"${whitespace.write}${memberLines}", "\n", 4)
   }
   implicit val structureMemberWriter: Writer[StructureMember] = Writer.write {
     case StructureMember(whitespace, maybeAssignment) =>
@@ -163,7 +162,7 @@ object ShapeWriter {
     case StructureMembers(whitespace, members) =>
       val memberLines = members.map {
         case (traitStatements, structureMember, ws) =>
-          s"${traitStatements.write}${structureMember.write},\n${ws.write}"
+          s"${traitStatements.write}${structureMember.write}\n${ws.write}"
       }.mkString
       indent(s"${whitespace.write}${memberLines}", "\n", 4)
   }
@@ -244,7 +243,7 @@ object ShapeWriter {
     case MapStatement(identifier, mixin, whitespace, members) =>
       s"map ${identifier.write}${mixin.write}${whitespace.write} {\n${indent(members.write, "\n", 4)}\n}"
     case UnionStatement(identifier, mixin, whitespace, members) =>
-      s"union ${identifier.write}${mixin.write}${whitespace.write} {\n${indent(members.write, "\n", 4)}\n}"
+      s"union ${identifier.write}${mixin.write}${whitespace.write} {\n${members.write}\n}"
     case ServiceStatement(identifier, mixin, whitespace1, nodeObject) =>
       s"service ${identifier.write} ${mixin.write}${whitespace1.write}${nodeObject.write}"
     case ResourceStatement(identifier, mixin, whitespace, nodeObject) =>

--- a/modules/formatter/src/writer/ShapeWriter.scala
+++ b/modules/formatter/src/writer/ShapeWriter.scala
@@ -236,7 +236,7 @@ object ShapeWriter {
   }
 
   implicit val structureResource: Writer[StructureResource] = Writer.write {
-    case StructureResource(shapeId) => s"${shapeId.write}"
+    case StructureResource(shapeId) => s" for ${shapeId.write}"
   }
 
   implicit val shapeBodyWriter: Writer[ShapeBody] = Writer.write {

--- a/modules/formatter/src/writer/ShapeWriter.scala
+++ b/modules/formatter/src/writer/ShapeWriter.scala
@@ -122,17 +122,20 @@ object ShapeWriter {
 
   implicit val valueAssignmentWriter: Writer[ValueAssignment] = Writer.write {
     case ValueAssignment(value, whitespace) =>
-      s" = ${value.write}${whitespace.write}"
+      s" = ${value.write}\n${whitespace.write}"
   }
 
   implicit val enumShapeMembersWriter: Writer[EnumShapeMembers] = Writer.write {
     case EnumShapeMembers(whitespace, members) =>
       val memberLines = members
         .map { case (ts, identifiers, maybeValue, ws) =>
-          s"${ts.write}${identifiers.write}${maybeValue.write}${ws.write}"
+          val endLine = maybeValue
+            .map(v => s"${v.write}${ws.write}")
+            .getOrElse(s"\n${ws.write}")
+          s"${ts.write}${identifiers.write}${endLine}"
         }
         .toList
-        .mkString_("", "\n", "")
+        .mkString
       s"${whitespace.write}${memberLines}"
   }
   implicit val structureMemberTypeWriter: Writer[StructureMemberType] =
@@ -152,7 +155,7 @@ object ShapeWriter {
         case (traitStatements, structureMember, ws) =>
           s"${traitStatements.write}${structureMember.write}\n${ws.write}"
       }.mkString
-      indent(s"${whitespace.write}${memberLines}", "\n", 4)
+      s"${whitespace.write}${memberLines}"
   }
   implicit val structureMemberWriter: Writer[StructureMember] = Writer.write {
     case StructureMember(whitespace, maybeAssignment) =>
@@ -164,7 +167,7 @@ object ShapeWriter {
         case (traitStatements, structureMember, ws) =>
           s"${traitStatements.write}${structureMember.write}\n${ws.write}"
       }.mkString
-      indent(s"${whitespace.write}${memberLines}", "\n", 4)
+      s"${whitespace.write}${memberLines}"
   }
 
   implicit val inputShapeIdWriter: Writer[InputShapeId] = Writer.write {
@@ -178,7 +181,8 @@ object ShapeWriter {
 
   implicit val inlineStructureWriter: Writer[InlineStructure] = Writer.write {
     case InlineStructure(whitespace, traitStatements, mixin, ws1, members) =>
-      s" := {\n${whitespace.write}${traitStatements.write}${mixin.write}${ws1.write}${members.write}\n}"
+      val indented = indent(members.write, "\n", 4)
+      s" := {\n${whitespace.write}${traitStatements.write}${mixin.write}${ws1.write}${indented}\n}"
   }
   implicit val operationInputWriter: Writer[OperationInput] = Writer.write {
     case OperationInput(ws0, members, ws1) =>
@@ -243,7 +247,7 @@ object ShapeWriter {
     case MapStatement(identifier, mixin, whitespace, members) =>
       s"map ${identifier.write}${mixin.write}${whitespace.write} {\n${indent(members.write, "\n", 4)}\n}"
     case UnionStatement(identifier, mixin, whitespace, members) =>
-      s"union ${identifier.write}${mixin.write}${whitespace.write} {\n${members.write}\n}"
+      s"union ${identifier.write}${mixin.write}${whitespace.write} {\n${indent(members.write, "\n", 4)}\n}"
     case ServiceStatement(identifier, mixin, whitespace1, nodeObject) =>
       s"service ${identifier.write} ${mixin.write}${whitespace1.write}${nodeObject.write}"
     case ResourceStatement(identifier, mixin, whitespace, nodeObject) =>
@@ -259,7 +263,7 @@ object ShapeWriter {
           whitespace,
           members
         ) =>
-      s"structure ${identifier.write}${resource.write}${mixins.write}${whitespace.write} {\n${members.write}\n}"
+      s"structure ${identifier.write}${resource.write}${mixins.write}${whitespace.write} {\n${indent(members.write, "\n", 4)}\n}"
 
   }
 

--- a/modules/formatter/src/writer/ShapeWriter.scala
+++ b/modules/formatter/src/writer/ShapeWriter.scala
@@ -248,9 +248,9 @@ object ShapeWriter {
     case UnionStatement(identifier, mixin, whitespace, members) =>
       s"union ${identifier.write}${mixin.write}${whitespace.write} {\n${indent(members.write, "\n", 4)}\n}"
     case ServiceStatement(identifier, mixin, whitespace1, nodeObject) =>
-      s"service ${identifier.write} ${mixin.write}${whitespace1.write} {\n${nodeObject.write}\n}"
+      s"service ${identifier.write} ${mixin.write}${whitespace1.write}${nodeObject.write}"
     case ResourceStatement(identifier, mixin, whitespace, nodeObject) =>
-      s"resource ${identifier.write} ${mixin.write}${whitespace.write} {\n${nodeObject.write}\n}"
+      s"resource ${identifier.write} ${mixin.write}${whitespace.write}${nodeObject.write}"
     case OperationStatement(identifier, mixin, whitespace, operationBody) =>
       s"operation ${identifier.write} ${mixin.write}${whitespace.write}{\n${indent(operationBody.write, "\n", 4)}\n}"
     case ListStatement(identifier, mixin, whitespace, members) =>

--- a/modules/formatter/src/writer/SmithyTraitWriter.scala
+++ b/modules/formatter/src/writer/SmithyTraitWriter.scala
@@ -28,7 +28,7 @@ import ast.{
   TraitStructureKeyValuePair
 }
 import ast.SmithyTraitBodyValue.{NodeValueCase, SmithyTraitStructureCase}
-import util.string_ops.formatEnum
+import util.string_ops.{indent, formatEnum}
 import NodeWriter.nodeValueWriter
 import ShapeIdWriter.shapeIdWriter
 import WhiteSpaceWriter.{breakWriter, wsWriter}
@@ -76,7 +76,7 @@ object SmithyTraitWriter {
     }
   implicit val applyBlockWriter: Writer[ApplyStatementBlock] = Writer.write {
     case ApplyStatementBlock(shapeId, ws0, traitStatements, br) =>
-      s"apply ${shapeId.write} ${ws0.write}{${traitStatements.write}}${br.write}"
+      s"apply ${shapeId.write} ${ws0.write}{\n${indent(traitStatements.write, "\n", 4)}\n}${br.write}"
   }
   implicit val applyStatementWriter: Writer[ApplyStatement] = Writer.write {
     _.either.write

--- a/modules/formatter/src/writer/SmithyTraitWriter.scala
+++ b/modules/formatter/src/writer/SmithyTraitWriter.scala
@@ -28,7 +28,7 @@ import ast.{
   TraitStructureKeyValuePair
 }
 import ast.SmithyTraitBodyValue.{NodeValueCase, SmithyTraitStructureCase}
-import util.string_ops.{indent, formatEnum}
+import util.string_ops.indent
 import NodeWriter.nodeValueWriter
 import ShapeIdWriter.shapeIdWriter
 import WhiteSpaceWriter.{breakWriter, wsWriter}
@@ -44,10 +44,7 @@ object SmithyTraitWriter {
     case SmithyTrait(shapeId, traitBody) =>
       val id = shapeId.write
       val body = traitBody.write
-      val reformatted = if (id.equalsIgnoreCase("enum")) {
-        formatEnum(body)
-      } else body
-      s"@$id$reformatted"
+      s"@$id$body"
   }
   implicit val traitBodyWriter: Writer[TraitBody] = Writer.write {
     case TraitBody(ws0, traitBodyValue, ws1) =>

--- a/modules/formatter/src/writer/WhiteSpaceWriter.scala
+++ b/modules/formatter/src/writer/WhiteSpaceWriter.scala
@@ -36,7 +36,7 @@ object WhiteSpaceWriter {
   }
   implicit val wsWriter: Writer[Whitespace] =
     Writer.write(
-      _.whitespace.writeN
+      _.comments.writeN
     )
 
   /*

--- a/modules/formatter/tests/src/FormatterSpec.scala
+++ b/modules/formatter/tests/src/FormatterSpec.scala
@@ -148,7 +148,7 @@ final class FormatterSpec extends munit.FunSuite {
     formatTest(src, expected)
   }
 
-  test("format test - comment beteen trait and shape") {
+  test("format test - comment between trait and shape") {
     val src = """|$version: "2.0"
                  |
                  |namespace test
@@ -173,7 +173,7 @@ final class FormatterSpec extends munit.FunSuite {
     formatTest(src, expected)
   }
 
-  test("format test - comments beteen trait and shape") {
+  test("format test - comments between trait and shape") {
     val src = """|$version: "2.0"
                  |
                  |namespace test

--- a/modules/formatter/tests/src/FormatterSpec.scala
+++ b/modules/formatter/tests/src/FormatterSpec.scala
@@ -549,4 +549,43 @@ final class FormatterSpec extends munit.FunSuite {
                       |""".stripMargin
     formatTest(src, expected)
   }
+
+  test("format test - node value formatting") {
+    val src = """|$version: "2.0"
+                 |
+                 |namespace test
+                 |
+                 |service MyService {
+                 |  operations: [A, B, C]
+                 |  operations: [
+                 |    // comment 1
+                 |    A
+                 |    /// comment 2
+                 |    B
+                 |  ]
+                 |  errors: [E1, E2]
+                 |}
+                 |""".stripMargin
+    val expected = """|$version: "2.0"
+                      |
+                      |namespace test
+                      |
+                      |service MyService {
+                      |    operations: [
+                      |        A
+                      |        B
+                      |        C
+                      |    ]
+                      |    operations: [
+                      |        // comment 1
+                      |        A
+                      |        /// comment 2
+                      |        B
+                      |    ]
+                      |    errors: [E1, E2]
+                      |}
+                      |
+                      |""".stripMargin
+    formatTest(src, expected)
+  }
 }

--- a/modules/formatter/tests/src/FormatterSpec.scala
+++ b/modules/formatter/tests/src/FormatterSpec.scala
@@ -392,4 +392,45 @@ final class FormatterSpec extends munit.FunSuite {
                        |""".stripMargin
     formatTest(src, expected)
   }
+
+  test("format test - support inline structure") {
+    val src = s"""|$$version: "2.0"
+                  |
+                  |namespace test
+                  |
+                  |operation Op {
+                  |  input: ShapeId
+                  |  output: ShapeId
+                  |}
+                  |
+                  |operation Op {
+                  |  input := {
+                  |    value: String
+                  |  }
+                  |  output := {
+                  |    value: String
+                  |  }
+                  |}
+                  |""".stripMargin
+    val expected = s"""|$$version: "2.0"
+                       |
+                       |namespace test
+                       |
+                       |operation Op {
+                       |    input: ShapeId
+                       |    output: ShapeId
+                       |}
+                       |
+                       |operation Op {
+                       |    input := {
+                       |        value: String
+                       |    }
+                       |    output := {
+                       |        value: String
+                       |    }
+                       |}
+                       |
+                       |""".stripMargin
+    formatTest(src, expected)
+  }
 }

--- a/modules/formatter/tests/src/FormatterSpec.scala
+++ b/modules/formatter/tests/src/FormatterSpec.scala
@@ -232,6 +232,45 @@ final class FormatterSpec extends munit.FunSuite {
     formatTest(src, expected)
   }
 
+  test("format test - structure with commented members") {
+    val src = """|$version: "2.0"
+                 |
+                 |namespace test
+                 |
+                 |structure MyStruct {
+                 |  @doc("data")
+                 |  /// comment 1
+                 |  this: String,
+                 |  /// comment 2
+                 |  that: Integer
+                 |}
+                 |
+                 |structure MyStructDefault {
+                 |  // some comment
+                 |  other: Integer = 1
+                 |}
+                 |""".stripMargin
+    val expected = """|$version: "2.0"
+                      |
+                      |namespace test
+                      |
+                      |structure MyStruct {
+                      |    @doc("data")
+                      |    /// comment 1
+                      |    this: String,
+                      |    /// comment 2
+                      |    that: Integer,
+                      |}
+                      |
+                      |structure MyStructDefault {
+                      |    // some comment
+                      |    other: Integer = 1,
+                      |}
+                      |
+                      |""".stripMargin
+    formatTest(src, expected)
+  }
+
   test("format test - identation on shape with body") {
     val src = """|$version: "2.0"
                  |
@@ -257,11 +296,11 @@ final class FormatterSpec extends munit.FunSuite {
                       |
                       |structure MyStruct {
                       |    this: String,
-                      |    that: Integer
+                      |    that: Integer,
                       |}
                       |
                       |structure MyStructDefault {
-                      |    other: Integer = 1
+                      |    other: Integer = 1,
                       |}
                       |
                       |union MyUnion {
@@ -423,10 +462,10 @@ final class FormatterSpec extends munit.FunSuite {
                        |
                        |operation Op {
                        |    input := {
-                       |        value: String
+                       |        value: String,
                        |    }
                        |    output := {
-                       |        value: String
+                       |        value: String,
                        |    }
                        |}
                        |

--- a/modules/formatter/tests/src/FormatterSpec.scala
+++ b/modules/formatter/tests/src/FormatterSpec.scala
@@ -206,11 +206,15 @@ final class FormatterSpec extends munit.FunSuite {
                  |namespace test
                  |
                  |enum MyEnum {
+                 |  // comment 1
                  |  VALUE1,
+                 |  /// comment 2
                  |    VALUE2
                  |}
                  |enum OtherEnum {
+                 |  /// comment 1
                  |  V1 = "v1"
+                 |//comment 2
                  |V2 = "v2"
                  |}
                  |""".stripMargin
@@ -219,12 +223,16 @@ final class FormatterSpec extends munit.FunSuite {
                       |namespace test
                       |
                       |enum MyEnum {
+                      |    // comment 1
                       |    VALUE1
+                      |    /// comment 2
                       |    VALUE2
                       |}
                       |
                       |enum OtherEnum {
+                      |    /// comment 1
                       |    V1 = "v1"
+                      |    // comment 2
                       |    V2 = "v2"
                       |}
                       |

--- a/modules/formatter/tests/src/FormatterSpec.scala
+++ b/modules/formatter/tests/src/FormatterSpec.scala
@@ -677,6 +677,7 @@ final class FormatterSpec extends munit.FunSuite {
                  |
                  |structure MyResourceIdentifiers for MyResource {
                  |    $id
+                 |    value: SomeMember$list
                  |}
                  |""".stripMargin
     val expected = """|$version: "2.0"
@@ -691,6 +692,39 @@ final class FormatterSpec extends munit.FunSuite {
                       |
                       |structure MyResourceIdentifiers for MyResource {
                       |    $id
+                      |    value: SomeMember$list
+                      |}
+                      |
+                      |""".stripMargin
+    formatTest(src, expected)
+  }
+
+  test("elided member") {
+    val src = """|$version: "2.0"
+                 |
+                 |namespace test
+                 |
+                 |list MixedList with [MixinList] {
+                 |  $member
+                 |}
+                 |
+                 |map MixedMap with [MixinMap] {
+                 |  $key
+                 |  $value
+                 |}
+                 |
+                 |""".stripMargin
+    val expected = """|$version: "2.0"
+                      |
+                      |namespace test
+                      |
+                      |list MixedList with [MixinList] {
+                      |    $member
+                      |}
+                      |
+                      |map MixedMap with [MixinMap] {
+                      |    $key
+                      |    $value
                       |}
                       |
                       |""".stripMargin

--- a/modules/formatter/tests/src/FormatterSpec.scala
+++ b/modules/formatter/tests/src/FormatterSpec.scala
@@ -628,6 +628,9 @@ final class FormatterSpec extends munit.FunSuite {
                  |operation SomeOp {
                  |    errors: [E1, E2]
                  |}
+                 |operation SomeOp {
+                 |    errors: []
+                 |}
                  |""".stripMargin
     val expected = """|$version: "2.0"
                       |
@@ -667,6 +670,10 @@ final class FormatterSpec extends munit.FunSuite {
                       |
                       |operation SomeOp {
                       |    errors: [E1, E2]
+                      |}
+                      |
+                      |operation SomeOp {
+                      |    errors: []
                       |}
                       |
                       |""".stripMargin

--- a/modules/formatter/tests/src/FormatterSpec.scala
+++ b/modules/formatter/tests/src/FormatterSpec.scala
@@ -625,4 +625,28 @@ final class FormatterSpec extends munit.FunSuite {
                       |""".stripMargin
     formatTest(src, expected)
   }
+
+  test("format test - apply formatting") {
+    val src = """|$version: "2.0"
+                 |
+                 |namespace test
+                 |
+                 |apply Foo$baz {
+                 |    @documentation("Hi")
+                 |    @internal
+                 |    @deprecated
+                 |}
+                 |""".stripMargin
+    val expected = """|$version: "2.0"
+                      |
+                      |namespace test
+                      |
+                      |apply Foo$baz {
+                      |    @documentation("Hi")
+                      |    @internal
+                      |    @deprecated
+                      |}
+                      |""".stripMargin
+    formatTest(src, expected)
+  }
 }

--- a/modules/formatter/tests/src/FormatterSpec.scala
+++ b/modules/formatter/tests/src/FormatterSpec.scala
@@ -300,4 +300,60 @@ final class FormatterSpec extends munit.FunSuite {
                       |""".stripMargin
     formatTest(src, expected)
   }
+
+  test("format test - multiple mixins") {
+    val src = """|$version: "2.0"
+                 |
+                 |namespace test
+                 |
+                 |structure Struct with [
+                 |    Mixin
+                 |    Mixin
+                 |    Mixin
+                 |    Mixin
+                 |    Mixin
+                 |    Mixin
+                 |    Mixin
+                 |] {}
+                 |
+                 |structure Struct with [
+                 |    Mixin
+                 |    Mixin
+                 |] {}
+                 |
+                 |structure Struct with [
+                 |    // Just one but w/ comment
+                 |    Mixin
+                 |] {}
+                 |""".stripMargin
+    val expected = """|$version: "2.0"
+                      |
+                      |namespace test
+                      |
+                      |structure Struct with [
+                      |    Mixin,
+                      |    Mixin,
+                      |    Mixin,
+                      |    Mixin,
+                      |    Mixin,
+                      |    Mixin,
+                      |    Mixin
+                      |] {
+                      |
+                      |}
+                      |
+                      |structure Struct with [Mixin, Mixin] {
+                      |
+                      |}
+                      |
+                      |structure Struct with [
+                      |    // Just one but w/ comment
+                      |    Mixin
+                      |] {
+                      |
+                      |}
+                      |
+                      |""".stripMargin
+    formatTest(src, expected)
+  }
 }

--- a/modules/formatter/tests/src/FormatterSpec.scala
+++ b/modules/formatter/tests/src/FormatterSpec.scala
@@ -217,6 +217,11 @@ final class FormatterSpec extends munit.FunSuite {
                  |//comment 2
                  |V2 = "v2"
                  |}
+                 |
+                 |@enum([
+                 |    /// Invalid!
+                 |    { name: "X", value: "X"}
+                 |]) string Features
                  |""".stripMargin
     val expected = """|$version: "2.0"
                       |
@@ -235,6 +240,15 @@ final class FormatterSpec extends munit.FunSuite {
                       |    // comment 2
                       |    V2 = "v2"
                       |}
+                      |
+                      |@enum([
+                      |    /// Invalid!
+                      |    {
+                      |        name: "X"
+                      |        value: "X"
+                      |    }
+                      |])
+                      |string Features
                       |
                       |""".stripMargin
     formatTest(src, expected)

--- a/modules/formatter/tests/src/FormatterSpec.scala
+++ b/modules/formatter/tests/src/FormatterSpec.scala
@@ -663,4 +663,37 @@ final class FormatterSpec extends munit.FunSuite {
                       |""".stripMargin
     formatTest(src, expected)
   }
+
+  test("structure with for resource") {
+    val src = """|$version: "2.0"
+                 |
+                 |namespace test
+                 |
+                 |resource MyResource {
+                 |    identifiers: {
+                 |        id: String
+                 |    }
+                 |}
+                 |
+                 |structure MyResourceIdentifiers for MyResource {
+                 |    $id
+                 |}
+                 |""".stripMargin
+    val expected = """|$version: "2.0"
+                      |
+                      |namespace test
+                      |
+                      |resource MyResource {
+                      |    identifiers: {
+                      |        id: String
+                      |    }
+                      |}
+                      |
+                      |structure MyResourceIdentifiers for MyResource {
+                      |    $id
+                      |}
+                      |
+                      |""".stripMargin
+    formatTest(src, expected)
+  }
 }

--- a/modules/formatter/tests/src/FormatterSpec.scala
+++ b/modules/formatter/tests/src/FormatterSpec.scala
@@ -505,6 +505,7 @@ final class FormatterSpec extends munit.FunSuite {
                 |service Service {
                 |  version: "2"
                 |}
+                |service Service { }
                 |""".stripMargin
     val expected = """|$version: "2.0"
                       |
@@ -516,6 +517,10 @@ final class FormatterSpec extends munit.FunSuite {
                       |
                       |service Service {
                       |    version: "2"
+                      |}
+                      |
+                      |service Service {
+                      |
                       |}
                       |
                       |""".stripMargin

--- a/modules/formatter/tests/src/FormatterSpec.scala
+++ b/modules/formatter/tests/src/FormatterSpec.scala
@@ -272,4 +272,32 @@ final class FormatterSpec extends munit.FunSuite {
                       |""".stripMargin
     formatTest(src, expected)
   }
+
+  test("format test - map key/value") {
+    val src = """|$version: "2.0"
+                 |
+                 |namespace test
+                 |
+                 |map Milestone {
+                 |    // some doc
+                 |    // other doc
+                 |    key: String,
+                 |
+                 |    value: Milestone
+                 |}
+                 |""".stripMargin
+    val expected = """|$version: "2.0"
+                      |
+                      |namespace test
+                      |
+                      |map Milestone {
+                      |    // some doc
+                      |    // other doc
+                      |    key: String
+                      |    value: Milestone
+                      |}
+                      |
+                      |""".stripMargin
+    formatTest(src, expected)
+  }
 }

--- a/modules/formatter/tests/src/FormatterSpec.scala
+++ b/modules/formatter/tests/src/FormatterSpec.scala
@@ -433,4 +433,32 @@ final class FormatterSpec extends munit.FunSuite {
                        |""".stripMargin
     formatTest(src, expected)
   }
+
+  test("format test - support node object in service/resource") {
+    val src = """|$version: "2.0"
+                |
+                |namespace test
+                |
+                |resource SubscriberResource {
+                |    read: GetSubscriber
+                |}
+                |service Service {
+                |  version: "2"
+                |}
+                |""".stripMargin
+    val expected = """|$version: "2.0"
+                      |
+                      |namespace test
+                      |
+                      |resource SubscriberResource {
+                      |    read: GetSubscriber
+                      |}
+                      |
+                      |service Service {
+                      |    version: "2"
+                      |}
+                      |
+                      |""".stripMargin
+    formatTest(src, expected)
+  }
 }

--- a/modules/formatter/tests/src/FormatterSpec.scala
+++ b/modules/formatter/tests/src/FormatterSpec.scala
@@ -500,4 +500,27 @@ final class FormatterSpec extends munit.FunSuite {
                       |""".stripMargin
     formatTest(src, expected)
   }
+
+  test("format test - number") {
+    val src = """|$version: "2.0"
+                 |
+                 |namespace test
+                 |
+                 |structure Value {
+                 |  @range(a: -1.0, b: 2, c: 1E10, d: -1.12E-10)
+                 |  a: Int
+                 |}
+                 |""".stripMargin
+    val expected = """|$version: "2.0"
+                      |
+                      |namespace test
+                      |
+                      |structure Value {
+                      |    @range(a: -1.0, b: 2, c: 1E10, d: -1.12E-10)
+                      |    a: Int,
+                      |}
+                      |
+                      |""".stripMargin
+    formatTest(src, expected)
+  }
 }

--- a/modules/formatter/tests/src/FormatterSpec.scala
+++ b/modules/formatter/tests/src/FormatterSpec.scala
@@ -356,4 +356,40 @@ final class FormatterSpec extends munit.FunSuite {
                       |""".stripMargin
     formatTest(src, expected)
   }
+
+  test("format test - large documentation trait") {
+    val tq = "\"\"\""
+    val src = s"""|$$version: "2.0"
+                  |
+                  |namespace test
+                  |
+                  |@documentation(${tq}
+                  |  value
+                  |${tq})
+                  |string Value
+                  |
+                  |@other(${tq}
+                  |  value
+                  |  is
+                  |  multiline${tq})
+                  |string Value
+                  |""".stripMargin
+    val expected = s"""|$$version: "2.0"
+                       |
+                       |namespace test
+                       |
+                       |@documentation(${tq}
+                       |  value
+                       |${tq})
+                       |string Value
+                       |
+                       |@other(${tq}
+                       |  value
+                       |  is
+                       |  multiline${tq})
+                       |string Value
+                       |
+                       |""".stripMargin
+    formatTest(src, expected)
+  }
 }

--- a/modules/formatter/tests/src/FormatterSpec.scala
+++ b/modules/formatter/tests/src/FormatterSpec.scala
@@ -485,6 +485,22 @@ final class FormatterSpec extends munit.FunSuite {
                   |    value: String
                   |  }
                   |}
+                  |
+                  |operation Op {
+                  |  input := @someTrait {
+                  |    value: String
+                  |  }
+                  |
+                  |  output := with [Mixin] {
+                  |    value: String
+                  |  }
+                  |}
+                  |
+                  |operation Op {
+                  |    input := @someTrait with [Mixin] {
+                  |        value: String
+                  |    }
+                  |}
                   |""".stripMargin
     val expected = s"""|$$version: "2.0"
                        |
@@ -500,6 +516,23 @@ final class FormatterSpec extends munit.FunSuite {
                        |        value: String
                        |    }
                        |    output := {
+                       |        value: String
+                       |    }
+                       |}
+                       |
+                       |operation Op {
+                       |    input := @someTrait
+                       |     {
+                       |        value: String
+                       |    }
+                       |    output := with [Mixin] {
+                       |        value: String
+                       |    }
+                       |}
+                       |
+                       |operation Op {
+                       |    input := @someTrait
+                       |     with [Mixin] {
                        |        value: String
                        |    }
                        |}

--- a/modules/formatter/tests/src/FormatterSpec.scala
+++ b/modules/formatter/tests/src/FormatterSpec.scala
@@ -249,6 +249,13 @@ final class FormatterSpec extends munit.FunSuite {
                  |  // some comment
                  |  other: Integer = 1
                  |}
+                 |
+                 |union MyUnion {
+                 |    // some comment
+                 | this: String,
+                 |    /// some comment
+                 |orThat: Integer
+                 |}
                  |""".stripMargin
     val expected = """|$version: "2.0"
                       |
@@ -257,14 +264,21 @@ final class FormatterSpec extends munit.FunSuite {
                       |structure MyStruct {
                       |    @doc("data")
                       |    /// comment 1
-                      |    this: String,
+                      |    this: String
                       |    /// comment 2
-                      |    that: Integer,
+                      |    that: Integer
                       |}
                       |
                       |structure MyStructDefault {
                       |    // some comment
-                      |    other: Integer = 1,
+                      |    other: Integer = 1
+                      |}
+                      |
+                      |union MyUnion {
+                      |    // some comment
+                      |    this: String
+                      |    /// some comment
+                      |    orThat: Integer
                       |}
                       |
                       |""".stripMargin
@@ -295,17 +309,17 @@ final class FormatterSpec extends munit.FunSuite {
                       |namespace test
                       |
                       |structure MyStruct {
-                      |    this: String,
-                      |    that: Integer,
+                      |    this: String
+                      |    that: Integer
                       |}
                       |
                       |structure MyStructDefault {
-                      |    other: Integer = 1,
+                      |    other: Integer = 1
                       |}
                       |
                       |union MyUnion {
-                      |    this: String,
-                      |    orThat: Integer,
+                      |    this: String
+                      |    orThat: Integer
                       |}
                       |
                       |""".stripMargin
@@ -318,11 +332,10 @@ final class FormatterSpec extends munit.FunSuite {
                  |namespace test
                  |
                  |map Milestone {
-                 |    // some doc
-                 |    // other doc
-                 |    key: String,
-                 |
-                 |    value: Milestone
+                 |  // some doc
+                 |  key: String,
+                 |  // other doc
+                 |  value: Milestone
                  |}
                  |""".stripMargin
     val expected = """|$version: "2.0"
@@ -331,8 +344,8 @@ final class FormatterSpec extends munit.FunSuite {
                       |
                       |map Milestone {
                       |    // some doc
-                      |    // other doc
                       |    key: String
+                      |    // other doc
                       |    value: Milestone
                       |}
                       |
@@ -462,10 +475,10 @@ final class FormatterSpec extends munit.FunSuite {
                        |
                        |operation Op {
                        |    input := {
-                       |        value: String,
+                       |        value: String
                        |    }
                        |    output := {
-                       |        value: String,
+                       |        value: String
                        |    }
                        |}
                        |
@@ -517,7 +530,7 @@ final class FormatterSpec extends munit.FunSuite {
                       |
                       |structure Value {
                       |    @range(a: -1.0, b: 2, c: 1E10, d: -1.12E-10)
-                      |    a: Int,
+                      |    a: Int
                       |}
                       |
                       |""".stripMargin

--- a/modules/formatter/tests/src/FormatterSpec.scala
+++ b/modules/formatter/tests/src/FormatterSpec.scala
@@ -564,6 +564,22 @@ final class FormatterSpec extends munit.FunSuite {
                  |    B
                  |  ]
                  |  errors: [E1, E2]
+                 |    errors: [E3]
+                 |}
+                 |
+                 |operation SomeOp {
+                 |    errors: [E1, E2, E3]
+                 |}
+                 |
+                 |operation SomeOp {
+                 |    errors: [
+                 |      // one comment
+                 |      E1,
+                 |      E2
+                 |    ]
+                 |}
+                 |operation SomeOp {
+                 |    errors: [E1, E2]
                  |}
                  |""".stripMargin
     val expected = """|$version: "2.0"
@@ -582,6 +598,27 @@ final class FormatterSpec extends munit.FunSuite {
                       |        /// comment 2
                       |        B
                       |    ]
+                      |    errors: [E1, E2]
+                      |    errors: [E3]
+                      |}
+                      |
+                      |operation SomeOp {
+                      |    errors: [
+                      |        E1
+                      |        E2
+                      |        E3
+                      |    ]
+                      |}
+                      |
+                      |operation SomeOp {
+                      |    errors: [
+                      |        // one comment
+                      |        E1
+                      |        E2
+                      |    ]
+                      |}
+                      |
+                      |operation SomeOp {
                       |    errors: [E1, E2]
                       |}
                       |

--- a/modules/formatter/tests/src/ParserSpec.scala
+++ b/modules/formatter/tests/src/ParserSpec.scala
@@ -131,33 +131,26 @@ operation GetFilmography {
     assertEitherIsRight(result)
   }
 
-  test("enum with no space") {
+  test("enums") {
     val result =
       IdlParser.idlParser.parseAll(
         """|$version: "2.0"
            |
            |namespace test
            |
+           |// no spaces
            |enum OtherEnum {
            |    V1 ="v1",
            |    V2 = "v2"
            |}
-           |""".stripMargin
-      )
-    assertEitherIsRight(result)
-  }
-
-  test("enum with commas") {
-    val result =
-      IdlParser.idlParser.parseAll(
-        """|$version: "2.0"
            |
-           |namespace test
-           |
+           |// with commas
            |enum OtherEnum {
            |    V1 = "v1",
            |    V2 = "v2"
            |}
+           |
+           |enum A { FOO BAR BAZ }
            |""".stripMargin
       )
     assertEitherIsRight(result)

--- a/modules/formatter/tests/src/ParserSpec.scala
+++ b/modules/formatter/tests/src/ParserSpec.scala
@@ -216,8 +216,9 @@ operation GetFilmography {
            |
            |namespace test
            |
-           |structure LiveAndUnratedContentUpdated with [
-           |    LiveAndUnratedContent
+           |structure MyStruct with [
+           |    Mixin1
+           |    Mixin2
            |] {}
            |""".stripMargin
       )

--- a/modules/formatter/tests/src/ParserSpec.scala
+++ b/modules/formatter/tests/src/ParserSpec.scala
@@ -160,4 +160,20 @@ operation GetFilmography {
       )
     assertEitherIsRight(result)
   }
+
+  test("parse structure body with trailing space") {
+    // trailing white space on `value: String` is important
+    val result =
+      IdlParser.idlParser.parseAll(
+        """|$version: "2.0"
+           |
+           |namespace test
+           |
+           |structure GetSetInput {
+           |    value: String 
+           |}
+           |""".stripMargin
+      )
+    assertEitherIsRight(result)
+  }
 }

--- a/modules/formatter/tests/src/ParserSpec.scala
+++ b/modules/formatter/tests/src/ParserSpec.scala
@@ -99,7 +99,7 @@ operation GetFilmography {
            |}
            |""".stripMargin
       )
-    assert(result.isRight, s"Failed with ${result.swap.getOrElse(fail("err"))}")
+    assertEitherIsRight(result)
   }
 
   test("map") {
@@ -112,7 +112,7 @@ operation GetFilmography {
            |map Test {key: String value: String}
            |""".stripMargin
       )
-    assert(result.isRight, s"Failed with ${result.swap.getOrElse(fail("err"))}")
+    assertEitherIsRight(result)
   }
 
   test("trait") {
@@ -128,7 +128,7 @@ operation GetFilmography {
            |}
            |""".stripMargin
       )
-    assert(result.isRight, s"Failed with ${result.swap.getOrElse(fail("err"))}")
+    assertEitherIsRight(result)
   }
 
   test("enum with commas") {

--- a/modules/formatter/tests/src/ParserSpec.scala
+++ b/modules/formatter/tests/src/ParserSpec.scala
@@ -238,6 +238,33 @@ operation GetFilmography {
     assertEitherIsRight(result)
   }
 
+  test("inline structure with mixin") {
+    val result =
+      IdlParser.idlParser.parseAll(
+        """|$version: "2.0"
+           |
+           |namespace test
+           |
+           |@mixin
+           |structure NameBearer {
+           |    name: String
+           |}
+           |
+           |operation UsesMixins {
+           |    input := with [NameBearer] {
+           |        id: String
+           |    }
+           |
+           |    output := with [NameBearer] {
+           |        id: String
+           |    }
+           |}
+           |
+           |""".stripMargin
+      )
+    assertEitherIsRight(result)
+  }
+
   test("parse structure body with trailing space") {
     // trailing white space on `value: String` is important
     val result =

--- a/modules/formatter/tests/src/ParserSpec.scala
+++ b/modules/formatter/tests/src/ParserSpec.scala
@@ -144,6 +144,20 @@ operation GetFilmography {
            |}
            |""".stripMargin
       )
-    assert(result.isRight, s"Failed with ${result.swap.getOrElse(fail("err"))}")
+    assertEitherIsRight(result)
+  }
+
+  test("parse without trailing") {
+    val result =
+      IdlParser.idlParser.parseAll(
+        """|$version: "2.0"
+           |
+           |namespace test
+           |
+           |structure Personalization {
+           |  name: String
+           |}""".stripMargin
+      )
+    assertEitherIsRight(result)
   }
 }

--- a/modules/formatter/tests/src/ParserSpec.scala
+++ b/modules/formatter/tests/src/ParserSpec.scala
@@ -204,6 +204,20 @@ operation GetFilmography {
     assertEitherIsRight(result)
   }
 
+  test("set can be parsed") {
+    val result =
+      IdlParser.idlParser.parseAll(
+        """|$version: "2.0"
+           |
+           |namespace test
+           |
+           |set ASet {member:String}
+           |
+           |""".stripMargin
+      )
+    assertEitherIsRight(result)
+  }
+
   test("map w/o members") {
     val result =
       IdlParser.idlParser.parseAll(

--- a/modules/formatter/tests/src/ParserSpec.scala
+++ b/modules/formatter/tests/src/ParserSpec.scala
@@ -176,4 +176,20 @@ operation GetFilmography {
       )
     assertEitherIsRight(result)
   }
+
+  test("empty triple doc break") {
+    val result =
+      IdlParser.idlParser.parseAll(
+        """|$version: "2.0"
+           |
+           |namespace test
+           |
+           |///
+           |structure GetSetInput {
+           |    value: String
+           |}
+           |""".stripMargin
+      )
+    assertEitherIsRight(result)
+  }
 }

--- a/modules/formatter/tests/src/ParserSpec.scala
+++ b/modules/formatter/tests/src/ParserSpec.scala
@@ -225,6 +225,22 @@ operation GetFilmography {
     assertEitherIsRight(result)
   }
 
+  test("format test - large documentation trait") {
+    val tq = "\"\"\""
+    val src = s"""|$$version: "2.0"
+                  |
+                  |namespace test
+                  |
+                  |@documentation(${tq}
+                  |  value
+                  |${tq})
+                  |string Value
+                  |
+                  |""".stripMargin
+    val result = IdlParser.idlParser.parseAll(src)
+    assertEitherIsRight(result)
+  }
+
   // format: off
   val parsables = Seq(
     "just output" ->               """|operation OpName {

--- a/modules/formatter/tests/src/ParserSpec.scala
+++ b/modules/formatter/tests/src/ParserSpec.scala
@@ -131,6 +131,22 @@ operation GetFilmography {
     assertEitherIsRight(result)
   }
 
+  test("enum with no space") {
+    val result =
+      IdlParser.idlParser.parseAll(
+        """|$version: "2.0"
+           |
+           |namespace test
+           |
+           |enum OtherEnum {
+           |    V1 ="v1",
+           |    V2 = "v2"
+           |}
+           |""".stripMargin
+      )
+    assertEitherIsRight(result)
+  }
+
   test("enum with commas") {
     val result =
       IdlParser.idlParser.parseAll(

--- a/modules/formatter/tests/src/ParserSpec.scala
+++ b/modules/formatter/tests/src/ParserSpec.scala
@@ -207,4 +207,75 @@ operation GetFilmography {
       )
     assertEitherIsRight(result)
   }
+
+  // format: off
+  val parsables = Seq(
+    "just output" ->               """|operation OpName {
+                                      |  output: ShapeId
+                                      |}""".stripMargin,
+    "just input" ->                """|operation OpName {
+                                      |  input: ShapeId
+                                      |}""".stripMargin,
+    "just errors" ->               """|operation OpName {
+                                      |  errors: [ShapeId]
+                                      |}""".stripMargin,
+    "input/errors" ->              """|operation OpName {
+                                      |  input: ShapeId
+                                      |  errors: [ShapeId]
+                                      |}""".stripMargin,
+    "errors/input" ->              """|operation OpName {
+                                      |  errors: [ShapeId]
+                                      |  input: ShapeId
+                                      |}""".stripMargin,
+    "output/errors" ->             """|operation OpName {
+                                      |  output: ShapeId
+                                      |  errors: [ShapeId]
+                                      |}""".stripMargin,
+    "errors/output" ->             """|operation OpName {
+                                      |  errors: [ShapeId]
+                                      |  output: ShapeId
+                                      |}""".stripMargin,
+    "input/output" ->              """|operation OpName {
+                                      |  input: ShapeId
+                                      |  output: ShapeId
+                                      |}""".stripMargin,
+    "output/input" ->              """|operation OpName {
+                                      |  output: ShapeId
+                                      |  input: ShapeId
+                                      |}""".stripMargin,
+    "input/output/errors" ->       """|operation OpName {
+                                      |  input: ShapeId
+                                      |  output: ShapeId
+                                      |  errors: [ShapeId]
+                                      |}""".stripMargin,
+    "output/input/errors" ->       """|operation OpName {
+                                      |  output: ShapeId
+                                      |  input: ShapeId
+                                      |  errors: [ShapeId]
+                                      |}""".stripMargin,
+    "errors/input/output" ->       """|operation OpName {
+                                      |  errors: [ShapeId]
+                                      |  input: ShapeId
+                                      |  output: ShapeId
+                                      |}""".stripMargin,
+    "errors/output/input" ->       """|operation OpName {
+                                      |  errors: [ShapeId]
+                                      |  output: ShapeId
+                                      |  input: ShapeId
+                                      |}""".stripMargin
+  )
+  // format: on
+  parsables.map { case (name, op) =>
+    test(s"operation with $name can be parsed") {
+      val result = IdlParser.idlParser.parseAll(
+        s"""|$$version: "2.0"
+           |
+           |namespace test
+           |
+           |$op
+           |""".stripMargin
+      )
+      assertEitherIsRight(result)
+    }
+  }
 }

--- a/modules/formatter/tests/src/ParserSpec.scala
+++ b/modules/formatter/tests/src/ParserSpec.scala
@@ -192,4 +192,19 @@ operation GetFilmography {
       )
     assertEitherIsRight(result)
   }
+
+  test("structure with multiple mixins") {
+    val result =
+      IdlParser.idlParser.parseAll(
+        """|$version: "2.0"
+           |
+           |namespace test
+           |
+           |structure LiveAndUnratedContentUpdated with [
+           |    LiveAndUnratedContent
+           |] {}
+           |""".stripMargin
+      )
+    assertEitherIsRight(result)
+  }
 }

--- a/modules/formatter/tests/src/ParserSpec.scala
+++ b/modules/formatter/tests/src/ParserSpec.scala
@@ -190,6 +190,20 @@ operation GetFilmography {
     assertEitherIsRight(result)
   }
 
+  test("no spacing") {
+    val result =
+      IdlParser.idlParser.parseAll(
+        """|$version: "2.0"
+           |
+           |namespace test
+           |
+           |list MixinList {member:String}
+           |
+           |""".stripMargin
+      )
+    assertEitherIsRight(result)
+  }
+
   test("map w/o members") {
     val result =
       IdlParser.idlParser.parseAll(

--- a/modules/formatter/tests/src/ParserSpec.scala
+++ b/modules/formatter/tests/src/ParserSpec.scala
@@ -197,6 +197,26 @@ operation GetFilmography {
     assertEitherIsRight(result)
   }
 
+  test("map w/o members") {
+    val result =
+      IdlParser.idlParser.parseAll(
+        """|$version: "2.0"
+           |
+           |namespace test
+           |
+           |@mixin
+           |map MixinMap {
+           |    key: String
+           |    value: String
+           |}
+           |
+           |map MixedMap with [MixinMap] {}
+           |
+           |""".stripMargin
+      )
+    assertEitherIsRight(result)
+  }
+
   test("parse structure body with trailing space") {
     // trailing white space on `value: String` is important
     val result =

--- a/modules/formatter/tests/src/ParserSpec.scala
+++ b/modules/formatter/tests/src/ParserSpec.scala
@@ -177,6 +177,26 @@ operation GetFilmography {
     assertEitherIsRight(result)
   }
 
+  test("list w/o a member") {
+    val result =
+      IdlParser.idlParser.parseAll(
+        """|$version: "2.0"
+           |
+           |namespace test
+           |
+           |@mixin
+           |list MixinList {
+           |    member: String
+           |}
+           |
+           |list MixedList with [MixinList] {
+           |}
+           |
+           |""".stripMargin
+      )
+    assertEitherIsRight(result)
+  }
+
   test("parse structure body with trailing space") {
     // trailing white space on `value: String` is important
     val result =


### PR DESCRIPTION
1. diverge from the spec and support shape statement interspersed with BR rather than requiring a trailing BR 29167eb9beb68af5674075f9c7991d9fb049e85e
2. allow backtracking on optional value_assignment because otherwise the whitespace consumed is unavailable for the rest of the parsers 9ce027fea4b58c2dfddb3efe1dcc29e6bc04eada
3. tweak not_newline to support `///` and nothing else c5841b886f3228a3982b30aa2b0d3078f2302c08
4. allow mixins declaration with new lines in them (used when multiple mixin are used on one structure) e9758726c7422f54a229e5d61529fa9af237830d
5. tweak the operation parser to support operation input/output/errors out of order bf6c2da9ff76cf4ff4e919930216487f89696359
6. spacing around `=` in value assignment is optional: `*SP` f4678d1fe9cea59e7da3cfc590f6c3a76b7476fb