### PR TITLE
sanitize names coming from openapi better

### DIFF
--- a/modules/openapi/src/internals/IModelToSmithy.scala
+++ b/modules/openapi/src/internals/IModelToSmithy.scala
@@ -222,9 +222,21 @@ final class IModelToSmithy(useEnumTraitSyntax: Boolean)
         ShapeId.fromParts(
           sanitizeNamespace(modelId.namespace.show),
           sanitizeName(modelId.name.segments.mkString_("")),
-          sanitizeForDigitStart(memberName.value.toString).replaceAll("-", "_")
+          sanitizeMemberName(memberName.value.toString)
         )
     }
+  }
+
+  private def removeInvalidCharactersForName(s: String): String = {
+    s.filter(c =>
+      c.isLetterOrDigit || c == '_'
+    ) // names can only contain letters, digits, and underscores
+  }
+
+  private def removeInvalidCharactersForNamespace(s: String): String = {
+    s.filter(c =>
+      c.isLetterOrDigit || c == '_' || c == '.'
+    ) // names can only contain letters, digits, underscores, and dots
   }
 
   // if name starts with a number, prefix with n
@@ -233,15 +245,21 @@ final class IModelToSmithy(useEnumTraitSyntax: Boolean)
     else id
 
   private def sanitizeNamespace(id: String): String = {
-    sanitizeForDigitStart(id).replaceAll("-", "_")
+    removeInvalidCharactersForNamespace(
+      sanitizeForDigitStart(id).replaceAll("-", "_")
+    )
   }
 
   private def sanitizeName(id: String): String = {
-    StringUtil.toCamelCase(sanitizeForDigitStart(id))
+    removeInvalidCharactersForName(
+      StringUtil.toCamelCase(sanitizeForDigitStart(id))
+    )
   }
 
   private def sanitizeMemberName(id: String): String = {
-    sanitizeForDigitStart(id).replaceAll("-", "_")
+    removeInvalidCharactersForName(
+      sanitizeForDigitStart(id).replaceAll("-", "_")
+    )
   }
 
   /** Used to replace things like `/path/{some-case}/rest with

--- a/modules/openapi/src/internals/IModelToSmithy.scala
+++ b/modules/openapi/src/internals/IModelToSmithy.scala
@@ -99,11 +99,17 @@ final class IModelToSmithy(useEnumTraitSyntax: Boolean)
         val builder =
           UnionShape.builder().id(id.toSmithy).addHints(hints)
         altNames.foreach { alt =>
+          val memName = alt.id.memberName.value.toString
+          val nameWillNeedChange = sanitizeMemberName(memName) != memName
+          val jsonNameHint =
+            if (nameWillNeedChange)
+              List(Hint.JsonName(memName))
+            else List.empty
           val member = MemberShape
             .builder()
             .id(alt.id.toSmithy)
             .target(alt.tpe.toSmithy)
-            .addHints(alt.hints)
+            .addHints(alt.hints ++ jsonNameHint)
             .build()
           builder.addMember(member)
         }

--- a/modules/openapi/src/internals/IModelToSmithy.scala
+++ b/modules/openapi/src/internals/IModelToSmithy.scala
@@ -49,8 +49,7 @@ final class IModelToSmithy(useEnumTraitSyntax: Boolean)
       case Structure(id, fields, _, structHints) =>
         val members = fields.map { case Field(id, tpe, hints) =>
           val memName = id.memberName.value.toString
-          val nameWillNeedChange =
-            memName.headOption.exists(_.isDigit) || memName.contains("-")
+          val nameWillNeedChange = sanitizeMemberName(memName) != memName
           def isHeaderOrQuery = hints.exists {
             case Header(_)     => true
             case QueryParam(_) => true

--- a/modules/openapi/tests/src/StructureSpec.scala
+++ b/modules/openapi/tests/src/StructureSpec.scala
@@ -402,6 +402,7 @@ final class StructureSpec extends munit.FunSuite {
     val expectedString = """|namespace foo
                       |
                       |structure Object {
+                      | @jsonName("version3.1")
                       | version31: String
                       |}
                       |""".stripMargin

--- a/modules/openapi/tests/src/StructureSpec.scala
+++ b/modules/openapi/tests/src/StructureSpec.scala
@@ -384,4 +384,29 @@ final class StructureSpec extends munit.FunSuite {
     TestUtils.runConversionTest(openapiString, expectedString)
   }
 
+  test("structures - property name sanitization") {
+    val openapiString = """|openapi: '3.0.'
+                     |info:
+                     |  title: test
+                     |  version: '1.0'
+                     |paths: {}
+                     |components:
+                     |  schemas:
+                     |    Object:
+                     |      type: object
+                     |      properties:
+                     |        version3.1:
+                     |          type: string
+                     |""".stripMargin
+
+    val expectedString = """|namespace foo
+                      |
+                      |structure Object {
+                      | version31: String
+                      |}
+                      |""".stripMargin
+
+    TestUtils.runConversionTest(openapiString, expectedString)
+  }
+
 }

--- a/modules/openapi/tests/src/UnionSpec.scala
+++ b/modules/openapi/tests/src/UnionSpec.scala
@@ -510,4 +510,57 @@ final class UnionSpec extends munit.FunSuite {
 
     TestUtils.runConversionTest(openapiString, expectedString)
   }
+
+  test("unions - sanitize names") {
+    val openapiString = """|openapi: '3.0.'
+                     |info:
+                     |  title: test
+                     |  version: '1.0'
+                     |paths: {}
+                     |components:
+                     |  schemas:
+                     |    Number:
+                     |      type: object
+                     |      properties:
+                     |        3three:
+                     |          type: integer
+                     |      required:
+                     |        - 3three
+                     |    Text:
+                     |      type: object
+                     |      properties:
+                     |        version1.1:
+                     |          type: string
+                     |      required:
+                     |        - version1.1
+                     |    TestUnion:
+                     |      oneOf:
+                     |        - $ref: '#/components/schemas/Number'
+                     |        - $ref: '#/components/schemas/Text'
+                     |""".stripMargin
+
+    val expectedString = """|namespace foo
+                      |
+                      |structure Number {
+                      |    @required
+                      |    @jsonName("3three")
+                      |    n3three: Integer,
+                      |}
+                      |
+                      |structure Text {
+                      |    @required
+                      |    @jsonName("version1.1")
+                      |    version11: String,
+                      |}
+                      |
+                      |union TestUnion {
+                      |    @jsonName("3three")
+                      |    n3three: Integer,
+                      |    @jsonName("version1.1")
+                      |    version11: String
+                      |}
+                      |""".stripMargin
+
+    TestUtils.runConversionTest(openapiString, expectedString)
+  }
 }


### PR DESCRIPTION
ShapeIds can only contain certain characters and still be valid. As such, this PR makes it so we will never create ShapeIds that contain invalid characters.
