### PR TITLE
Sort use statements, improve inline comment (w/ Break)

### DIFF
--- a/modules/formatter/src/ast/shapeId.scala
+++ b/modules/formatter/src/ast/shapeId.scala
@@ -25,18 +25,11 @@ case class RootShapeId(either: Either[AbsoluteRootShapeId, Identifier])
 
 case class AbsoluteRootShapeId(nameSpace: Namespace, identifier: Identifier)
 object AbsoluteRootShapeId {
-  implicit val ord: Ordering[AbsoluteRootShapeId] =
-    new Ordering[AbsoluteRootShapeId] {
-      import writers.Writer._
-      import writers.ShapeIdWriter._
-      override def compare(
-          x: AbsoluteRootShapeId,
-          y: AbsoluteRootShapeId
-      ): Int = {
-        Ordering[String].compare(x.write, y.write)
-      }
-
-    }
+  implicit val ord: Ordering[AbsoluteRootShapeId] = {
+    import writers.Writer._
+    import writers.ShapeIdWriter._
+    Ordering.by(_.write)
+  }
 }
 
 case class Namespace(identifier: Identifier, suffix: List[Identifier])

--- a/modules/formatter/src/ast/shapeId.scala
+++ b/modules/formatter/src/ast/shapeId.scala
@@ -24,6 +24,20 @@ case class ShapeId(
 case class RootShapeId(either: Either[AbsoluteRootShapeId, Identifier])
 
 case class AbsoluteRootShapeId(nameSpace: Namespace, identifier: Identifier)
+object AbsoluteRootShapeId {
+  implicit val ord: Ordering[AbsoluteRootShapeId] =
+    new Ordering[AbsoluteRootShapeId] {
+      import writers.Writer._
+      import writers.ShapeIdWriter._
+      override def compare(
+          x: AbsoluteRootShapeId,
+          y: AbsoluteRootShapeId
+      ): Int = {
+        Ordering[String].compare(x.write, y.write)
+      }
+
+    }
+}
 
 case class Namespace(identifier: Identifier, suffix: List[Identifier])
 

--- a/modules/formatter/src/ast/whitespace.scala
+++ b/modules/formatter/src/ast/whitespace.scala
@@ -21,7 +21,7 @@ import smithytranslate.formatter.ast.CommentType.{Documentation, Line}
 case object Comma {}
 case class Whitespace(comments: List[Comment])
 
-case class Break(comments: List[Comment])
+case class Break(inlineComment: Option[Comment], comments: List[Comment])
 sealed trait CommentType { self =>
   def write: String = self match {
     case Line          => "//"

--- a/modules/formatter/src/parsers/ShapeIdParser.scala
+++ b/modules/formatter/src/parsers/ShapeIdParser.scala
@@ -45,7 +45,7 @@ object ShapeIdParser {
       .map(Namespace.tupled)
   val absolute_root_shape_id: Parser[AbsoluteRootShapeId] =
     ((namespace <* Parser.char('#')) ~ identifier)
-      .map(AbsoluteRootShapeId.tupled)
+      .map(AbsoluteRootShapeId.apply.tupled)
   val root_shape_id: Parser[RootShapeId] =
     absolute_root_shape_id.backtrack
       .eitherOr(identifier)

--- a/modules/formatter/src/parsers/ShapeParser.scala
+++ b/modules/formatter/src/parsers/ShapeParser.scala
@@ -341,7 +341,7 @@ object ShapeParser {
   val shape_statement: Parser[ShapeStatement] = {
     val traitAndBody = trait_statements.with1 ~ shape_body
     val interspersedBr =
-      (traitAndBody.soft ~ br) | traitAndBody.map(_ -> Break(Nil))
+      (traitAndBody.soft ~ br) | traitAndBody.map(_ -> Break(None, Nil))
     interspersedBr.map { case ((a, b), c) =>
       ShapeStatement(a, b, c)
     }

--- a/modules/formatter/src/parsers/WhitespaceParser.scala
+++ b/modules/formatter/src/parsers/WhitespaceParser.scala
@@ -28,10 +28,12 @@ object WhitespaceParser {
   val comma: Parser[Unit] = Parser.char(',')
   // requires defer due to cyclic dependency between Break and Comment
   // deviates from ABNF due to the fact that in examples provided there can be multiple new lines in a row between shapes
-  lazy val br: Parser[Break] =
+  val br: Parser[Break] =
     Parser
-      .defer(sp.rep0.with1 *> commentOrNewline.rep <* ws)
-      .map(list => Break(list.toList.flatten))
+      .defer(sp.rep0.with1 *> commentOrNewline ~ ws)
+      .map { case (inlineComment, ws) =>
+        Break(inlineComment, ws.comments)
+      }
   private val not_newline: Parser0[String] =
     Parser.until(nl).?.map(_.getOrElse(""))
   val line_comment: Parser[Line] = Parser.string("//").as(Line)

--- a/modules/formatter/src/writer/ShapeWriter.scala
+++ b/modules/formatter/src/writer/ShapeWriter.scala
@@ -58,7 +58,7 @@ object ShapeWriter {
   }
   implicit val useSectionWriter: Writer[UseSection] = Writer.write {
     case UseSection(use_statements) =>
-      use_statements.writeN("", "", "\n")
+      use_statements.sortBy(_.absoluteRootShapeId).writeN("", "", "\n")
   }
 
   implicit val shapeSectionWriter: Writer[ShapeSection] = Writer.write {

--- a/modules/formatter/src/writer/WhiteSpaceWriter.scala
+++ b/modules/formatter/src/writer/WhiteSpaceWriter.scala
@@ -17,6 +17,7 @@ package formatter
 package writers
 
 import smithytranslate.formatter.ast.{Break, Comment, Whitespace}
+import smithytranslate.formatter.writers.Writer.WriterOps
 import smithytranslate.formatter.writers.Writer.WriterOpsIterable
 
 object WhiteSpaceWriter {
@@ -25,19 +26,26 @@ object WhiteSpaceWriter {
     s" ${string.trim}"
   }
 
-  implicit val breakWriter: Writer[Break] = Writer.write {
-    case Break(comments) =>
-      if (comments.isEmpty) "\n"
-      else s"${comments.writeN("\n", "", "")}"
-  }
   implicit val commentWriter: Writer[Comment] = Writer.write {
     case Comment(commentType, text) =>
       s"${commentType.write}${prefixWithWhiteSpace(text)}\n"
   }
+
   implicit val wsWriter: Writer[Whitespace] =
     Writer.write(
       _.comments.writeN
     )
+
+  implicit val breakWriter: Writer[Break] = Writer.write {
+    case Break(inlineComment, comments) => {
+      val inline =
+        inlineComment.map(c => prefixWithWhiteSpace(c.write)).getOrElse("")
+      val others =
+        if (comments.isEmpty) "\n"
+        else s"${comments.writeN("\n", "", "")}"
+      s"$inline$others"
+    }
+  }
 
   /*
   WS = 1*(SP / NL / Comment / ",") ; whitespace

--- a/modules/formatter/tests/src/FormatterSpec.scala
+++ b/modules/formatter/tests/src/FormatterSpec.scala
@@ -37,6 +37,99 @@ final class FormatterSpec extends munit.FunSuite {
       )
   }
 
+  test("control - 0") {
+    val src = """|$version: "2.0"
+                 |
+                 |namespace test
+                 |""".stripMargin
+    val expected = """|$version: "2.0"
+                      |
+                      |namespace test
+                      |
+                      |""".stripMargin
+    formatTest(src, expected)
+  }
+
+  test("control - 1") {
+    val src = """|$version: "2.0" //comment
+                 |
+                 |namespace test
+                 |""".stripMargin
+    val expected = """|$version: "2.0" // comment
+                      |
+                      |namespace test
+                      |
+                      |""".stripMargin
+    formatTest(src, expected)
+  }
+
+  test("control - 2") {
+    val src = """|$version: "2.0" /// comment
+                 |
+                 |namespace test
+                 |""".stripMargin
+    val expected = """|$version: "2.0" /// comment
+                      |
+                      |namespace test
+                      |
+                      |""".stripMargin
+    formatTest(src, expected)
+  }
+
+  test("control - 3") {
+    val src = """|/// triple comment
+                 |/// on multiline
+                 |$version: "2.0"
+                 |
+                 |namespace test
+                 |""".stripMargin
+    val expected = """|/// triple comment
+                      |/// on multiline
+                      |$version: "2.0"
+                      |
+                      |namespace test
+                      |
+                      |""".stripMargin
+    formatTest(src, expected)
+  }
+
+  test("control - 4") {
+    val src = """|// double comment
+                 |// on multiline
+                 |$version: "2.0"
+                 |
+                 |namespace test
+                 |
+                 |""".stripMargin
+    val expected = """|// double comment
+                      |// on multiline
+                      |$version: "2.0"
+                      |
+                      |namespace test
+                      |
+                      |""".stripMargin
+    formatTest(src, expected)
+  }
+
+  test("control - 5") {
+    val src = """|// double comment
+                 |/// and triple
+                 |// on multiline
+                 |$version: "2.0"
+                 |
+                 |namespace test
+                 |""".stripMargin
+    val expected = """|// double comment
+                      |/// and triple
+                      |// on multiline
+                      |$version: "2.0"
+                      |
+                      |namespace test
+                      |
+                      |""".stripMargin
+    formatTest(src, expected)
+  }
+
   test("format test - keep new line after control section") {
     val src = """|$version: "2.0"
                  |

--- a/modules/formatter/tests/src/FormatterSpec.scala
+++ b/modules/formatter/tests/src/FormatterSpec.scala
@@ -863,4 +863,29 @@ final class FormatterSpec extends munit.FunSuite {
                       |""".stripMargin
     formatTest(src, expected)
   }
+
+  test("sort use statements") {
+    val src = """|$version: "2.0"
+                 |
+                 |namespace test
+                 |
+                 |use a#a
+                 |use b#c
+                 |use b#a
+                 |use a#b
+                 |use a#b
+                 |""".stripMargin
+    val expected = """|$version: "2.0"
+                      |
+                      |namespace test
+                      |
+                      |use a#a
+                      |use a#b
+                      |use a#b
+                      |use b#a
+                      |use b#c
+                      |
+                      |""".stripMargin
+    formatTest(src, expected)
+  }
 }


### PR DESCRIPTION
Support for comments is still not perfect. Following the grammar to the letter leads to an AST that has comments (things you'd like to keep) in weird places.