### PR TITLE
update so proto file naming is more consistent

### DIFF
--- a/modules/proto/core/src/smithyproto/proto3/Compiler.scala
+++ b/modules/proto/core/src/smithyproto/proto3/Compiler.scala
@@ -132,8 +132,22 @@ class Compiler() {
     prefix :+ fileName
   }
 
-  private def toSnakeCase(name: String): String =
-    name.split("(?=\\p{Upper})").map(_.toLowerCase).mkString("_")
+  private def toSnakeCase(name: String): String = {
+    val (_, result) = name
+      .foldLeft((false, "")) { case ((wasLastUpper, acc), i) =>
+        val hasTrailingUnderscore = acc.lastOption.contains('_')
+        val maybeUnderscore =
+          if (
+            i.isUpper &&
+            acc.nonEmpty &&
+            !wasLastUpper &&
+            !hasTrailingUnderscore
+          ) "_"
+          else ""
+        (i.isUpper, acc + maybeUnderscore + i.toLower)
+      }
+    result
+  }
 
   private def findFieldIndex(m: MemberShape): Option[Int] =
     m.getTrait(classOf[ProtoIndexTrait]).toScala.map(_.getNumber)

--- a/modules/proto/core/tests/src/CompilerSuite.scala
+++ b/modules/proto/core/tests/src/CompilerSuite.scala
@@ -22,6 +22,25 @@ import software.amazon.smithy.model.Model
 import software.amazon.smithy.model.shapes.StringShape
 
 class CompilerSuite extends FunSuite {
+
+  private val someString = TopLevelDef.MessageDef(
+    Message(
+      "SomeString",
+      List(
+        MessageElement.FieldElement(
+          Field(
+            repeated = false,
+            deprecated = false,
+            Type.String,
+            "value",
+            1
+          )
+        )
+      ),
+      Nil
+    )
+  )
+
   test("compile a simple smithy model") {
     val namespace = "com.example"
     val sut = new Compiler()
@@ -45,23 +64,63 @@ class CompilerSuite extends FunSuite {
           ),
           List(
             TopLevelStatement(
-              TopLevelDef.MessageDef(
-                Message(
-                  "SomeString",
-                  List(
-                    MessageElement.FieldElement(
-                      Field(
-                        repeated = false,
-                        deprecated = false,
-                        Type.String,
-                        "value",
-                        1
-                      )
-                    )
-                  ),
-                  Nil
-                )
-              )
+              someString
+            )
+          ),
+          List.empty
+        )
+      )
+    )
+
+    Assertions.assertEquals(actual, expected)
+  }
+
+  test("correctly choose file name - all caps") {
+    namespaceTest("com.EXAMPLE", List("com", "example.proto"))
+  }
+
+  test("correctly choose file name - underscore") {
+    namespaceTest("com.some_example", List("com", "some_example.proto"))
+  }
+
+  test("correctly choose file name - leading underscore") {
+    namespaceTest("com._example", List("com", "_example.proto"))
+    namespaceTest("com._EXAMPLE", List("com", "_example.proto"))
+    namespaceTest("com._Example", List("com", "_example.proto"))
+  }
+
+  test("correctly choose file name - underscore and caps") {
+    namespaceTest("com.some_EXAMPLE", List("com", "some_example.proto"))
+    namespaceTest("com.SOME_EXAMPLE", List("com", "some_example.proto"))
+    namespaceTest("com.Some_Example", List("com", "some_example.proto"))
+    namespaceTest(
+      "com.Some_OTHER_Example",
+      List("com", "some_other_example.proto")
+    )
+  }
+
+  private def namespaceTest(namespace: String, expectedFilePath: List[String])(
+      implicit loc: Location
+  ): Unit = {
+    val sut = new Compiler()
+    val model = {
+      val mb = Model.builder()
+      mb.addShape(
+        StringShape.builder().id(s"$namespace#SomeString").build()
+      )
+      mb.build()
+    }
+    val actual = sut.compile(model)
+    val expected = List(
+      OutputFile(
+        expectedFilePath,
+        CompilationUnit(
+          Some(
+            namespace
+          ),
+          List(
+            TopLevelStatement(
+              someString
             )
           ),
           List.empty


### PR DESCRIPTION
This fixes an issue where a smithy namespace of `com.EXAMPLE` was leading to a proto file called `e_x_a_m_p_l_e.proto` being created. There are a few other edge cases that I addressed as well, see tests I add for more.