### PR TITLE
Use toSet(clazz) to find shapes

### DIFF
--- a/modules/traits/src/smithytranslate/BigDecimal.java
+++ b/modules/traits/src/smithytranslate/BigDecimal.java
@@ -20,6 +20,7 @@ import software.amazon.smithy.model.loader.Prelude;
 import software.amazon.smithy.model.traits.RequiredTrait;
 
 final public class BigDecimal {
+  static public ShapeId target = ShapeId.fromParts(Prelude.NAMESPACE, "String");
   static public Shape shape =
     StructureShape
       .builder()
@@ -27,7 +28,7 @@ final public class BigDecimal {
       .addMember(
         MemberShape.builder()
           .id("smithytranslate#BigDecimal$value")
-          .target(ShapeId.fromParts(Prelude.NAMESPACE, "String"))
+          .target(target)
           .addTrait(new RequiredTrait())
           .build()
       )

--- a/modules/traits/src/smithytranslate/BigInteger.java
+++ b/modules/traits/src/smithytranslate/BigInteger.java
@@ -20,6 +20,7 @@ import software.amazon.smithy.model.loader.Prelude;
 import software.amazon.smithy.model.traits.RequiredTrait;
 
 final public class BigInteger {
+  static public ShapeId target = ShapeId.fromParts(Prelude.NAMESPACE, "String");
 	static public Shape shape =
     StructureShape
       .builder()
@@ -27,7 +28,7 @@ final public class BigInteger {
       .addMember(
         MemberShape.builder()
           .id("smithytranslate#BigInteger$value")
-          .target(ShapeId.fromParts(Prelude.NAMESPACE, "String"))
+          .target(target)
           .addTrait(new RequiredTrait())
           .build()
       )

--- a/modules/traits/src/smithytranslate/Timestamp.java
+++ b/modules/traits/src/smithytranslate/Timestamp.java
@@ -20,6 +20,7 @@ import software.amazon.smithy.model.loader.Prelude;
 import software.amazon.smithy.model.traits.RequiredTrait;
 
 final public class Timestamp {
+  static public ShapeId target = ShapeId.fromParts(Prelude.NAMESPACE, "Long");
   static public Shape shape =
     StructureShape
       .builder()
@@ -27,7 +28,7 @@ final public class Timestamp {
       .addMember(
         MemberShape.builder()
           .id("smithytranslate#Timestamp$value")
-          .target(ShapeId.fromParts(Prelude.NAMESPACE, "Long"))
+          .target(target)
           .addTrait(new RequiredTrait())
           .build()
       )


### PR DESCRIPTION
When using `model.getShape` with a shapeId and relying on whether or the shape is there, we risk not finding shapes because of a bad shape id.

In this case, smithy.api#Timestamp does not exist, so the timestamp shape was never _used_ according to this logic. This resulted in the output protobuf models not having the smithytranslate.timestamp message exported