### PR TITLE
Exclude the reflect.properties file

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -241,6 +241,7 @@ object formatter extends BaseModule { outer =>
 
       override def assemblyRules: Seq[Assembly.Rule] =
         super.assemblyRules ++ Seq(
+          Assembly.Rule.Exclude("reflect.properties"),
           Assembly.Rule
             .Relocate("smithytranslate.**", "smithyfmt.smithytranslate.@1"),
           Assembly.Rule.Relocate("scala.**", "smithyfmt.scala.@1"),


### PR DESCRIPTION
Content is:

```
copyright.string=Copyright 2002-2022, LAMP/EPFL and Lightbend, Inc.
maven.version.number=2.13.10
osgi.version.number=2.13.10.v20221008-124105-VFINAL-4905801
shell.banner=%n     ________ ___   / /  ___%n    / __/ __// _ | / /  / _ |%n  __\\ \\/ /__/ __ |/ /__/ __ |%n /____/\\___/_/ |_/____/_/ | |%n                          |/  %s
version.number=2.13.10

```

excluding because it conflicts with other shaded
jar