### PR TITLE
Remove trailing comma when using newline

### DIFF
--- a/modules/formatter/src/writer/ShapeWriter.scala
+++ b/modules/formatter/src/writer/ShapeWriter.scala
@@ -95,7 +95,7 @@ object ShapeWriter {
           list
             .map(_.write)
             .map(indent(_, "\n", 4))
-            .mkString_("[\n", ",\n", s"\n${whitespace1.write}]")
+            .mkString_("[\n", "\n", s"\n${whitespace1.write}]")
         else list.map(_.write).mkString_("[", ", ", s"${whitespace1.write}]")
       s" with${whitespace.write} $values"
   }

--- a/modules/formatter/tests/src/FormatterSpec.scala
+++ b/modules/formatter/tests/src/FormatterSpec.scala
@@ -542,12 +542,12 @@ final class FormatterSpec extends munit.FunSuite {
                       |namespace test
                       |
                       |structure Struct with [
-                      |    Mixin,
-                      |    Mixin,
-                      |    Mixin,
-                      |    Mixin,
-                      |    Mixin,
-                      |    Mixin,
+                      |    Mixin
+                      |    Mixin
+                      |    Mixin
+                      |    Mixin
+                      |    Mixin
+                      |    Mixin
                       |    Mixin
                       |] {}
                       |


### PR DESCRIPTION
Mixins list can be separated by new line, in that
case we can remove the trailing comma to be more
more consistent with the rest of the formatting

Feedback from https://github.com/awslabs/smithy-language-server/pull/89