### PR TITLE
data examples trait in openapi conversion

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -401,7 +401,7 @@ object transitive extends BaseScalaModule {
 object Deps {
   object alloy {
     val core =
-      ivy"com.disneystreaming.alloy:alloy-core:0.1.15"
+      ivy"com.disneystreaming.alloy:alloy-core:0.1.16"
   }
   object circe {
     val jawn = ivy"io.circe::circe-jawn:0.14.5"

--- a/modules/openapi/src/internals/Hint.scala
+++ b/modules/openapi/src/internals/Hint.scala
@@ -45,5 +45,6 @@ object Hint {
   case class CurrentLocation(str: String) extends Hint
   case class TargetLocation(str: String) extends Hint
   case class JsonName(name: String) extends Hint
+  case class Examples(value: List[Node]) extends Hint
 }
 // format: on

--- a/modules/openapi/src/internals/IModelToSmithy.scala
+++ b/modules/openapi/src/internals/IModelToSmithy.scala
@@ -18,6 +18,7 @@ package smithytranslate.openapi.internals
 import alloy.DateFormatTrait
 import alloy.DiscriminatedUnionTrait
 import alloy.NullableTrait
+import alloy.DataExamplesTrait
 import alloy.openapi.OpenApiExtensionsTrait
 import alloy.UntaggedUnionTrait
 import alloy.UuidFormatTrait
@@ -305,6 +306,10 @@ final class IModelToSmithy(useEnumTraitSyntax: Boolean)
     case Hint.UniqueItems             => List(new UniqueItemsTrait())
     case Hint.Nullable                => List(new NullableTrait())
     case Hint.JsonName(value)         => List(new JsonNameTrait(value))
+    case Hint.Examples(examples) =>
+      val trt = DataExamplesTrait.builder
+      examples.foreach(ex => trt.addExample(ex))
+      List(trt.build)
     case Hint.Auth(schemes) =>
       val shapeIds = schemes.map {
         case _: SecurityScheme.ApiKey     => HttpApiKeyAuthTrait.ID

--- a/modules/openapi/src/internals/OpenApiToIModel.scala
+++ b/modules/openapi/src/internals/OpenApiToIModel.scala
@@ -708,7 +708,10 @@ private class OpenApiToIModel[F[_]: Parallel: TellShape: TellError](
             )
           }
         F.pure(
-          OpenApiObject(local.context.addHints(hints), fields)
+          OpenApiObject(
+            local.context.addHints(hints, retainTopLevel = true),
+            fields
+          )
             .withDescription(local)
         )
 

--- a/modules/openapi/src/internals/OpenApiToIModel.scala
+++ b/modules/openapi/src/internals/OpenApiToIModel.scala
@@ -563,6 +563,11 @@ private class OpenApiToIModel[F[_]: Parallel: TellShape: TellError](
     (updatedRange, error.flatten)
   }
 
+  private def getExamplesHint(schema: Schema[_]): Option[Hint.Examples] =
+    Option(schema.getExample())
+      .map(GetExtensions.anyToNode)
+      .map(n => Hint.Examples(List(n)))
+
   /*
    * The goal here is to match one layer of "Schema[_]" and
    * assign it to the corresponding pattern.
@@ -600,7 +605,10 @@ private class OpenApiToIModel[F[_]: Parallel: TellShape: TellError](
           )
           val topLevel = local.context.hints.filter(_ == Hint.TopLevel)
           val (range, rangeError) = getRangeTrait(local, prim)
-          val hints = List(length, range, pattern, sensitive, topLevel).flatten
+
+          val examples = getExamplesHint(local.schema)
+          val hints =
+            List(length, range, pattern, sensitive, topLevel, examples).flatten
           val errors = List(rangeError).flatten
           (hints, errors)
         }
@@ -625,9 +633,10 @@ private class OpenApiToIModel[F[_]: Parallel: TellShape: TellError](
       //     <item type>
       case s: ArraySchema if s.getUniqueItems =>
         val lengthConstraint = getCollectionLengthConstraint(local.schema)
+        val hints = getExamplesHint(s).toList ++ lengthConstraint
         F.pure(
           OpenApiSet(
-            local.context.addHints(lengthConstraint.toList),
+            local.context.addHints(hints),
             Local(
               local.context.append(Segment.Arbitrary(ci"Item")),
               s.getItems()
@@ -641,9 +650,10 @@ private class OpenApiToIModel[F[_]: Parallel: TellShape: TellError](
       //     <item type>
       case s: ArraySchema =>
         val lengthConstraint = getCollectionLengthConstraint(local.schema)
+        val hints = getExamplesHint(s).toList ++ lengthConstraint
         F.pure(
           OpenApiArray(
-            local.context.addHints(lengthConstraint.toList),
+            local.context.addHints(hints),
             Local(
               local.context.append(Segment.Arbitrary(ci"Item")),
               s.getItems()
@@ -656,9 +666,10 @@ private class OpenApiToIModel[F[_]: Parallel: TellShape: TellError](
       //   additionalProperties: schema
       case CaseMap(items) =>
         val lengthConstraint = getCollectionLengthConstraint(local.schema)
+        val hints = getExamplesHint(local.schema).toList ++ lengthConstraint
         F.pure(
           OpenApiMap(
-            local.context.addHints(lengthConstraint.toList),
+            local.context.addHints(hints),
             Local(
               local.context.append(Segment.Arbitrary(ci"Item")),
               items
@@ -688,6 +699,7 @@ private class OpenApiToIModel[F[_]: Parallel: TellShape: TellError](
           Option(s.getProperties()).map(_.asScala.toVector).toVector.flatten
         val required =
           Option(s.getRequired()).map(_.asScala).getOrElse(List.empty).toSet
+        val hints = getExamplesHint(s).toList
         val fields =
           properties.map { case (name, schema) =>
             (name, required(name)) -> Local(
@@ -695,7 +707,10 @@ private class OpenApiToIModel[F[_]: Parallel: TellShape: TellError](
               schema
             )
           }
-        F.pure(OpenApiObject(local.context, fields).withDescription(local))
+        F.pure(
+          OpenApiObject(local.context.addHints(hints), fields)
+            .withDescription(local)
+        )
 
       // O:
       //   allOf:

--- a/modules/openapi/tests/src/ExamplesSpec.scala
+++ b/modules/openapi/tests/src/ExamplesSpec.scala
@@ -1,0 +1,275 @@
+/* Copyright 2022 Disney Streaming
+ *
+ * Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package smithytranslate.openapi
+
+final class ExamplesSpec extends munit.FunSuite {
+
+  test("example - integer") {
+    val openapiString = """|openapi: '3.0.'
+                           |info:
+                           |  title: test
+                           |  version: '1.0'
+                           |paths: {}
+                           |components:
+                           |  schemas:
+                           |    Id:
+                           |      type: integer
+                           |      format: int32
+                           |      example: 1
+                           |""".stripMargin
+
+    val expectedString = """|namespace foo
+                            |
+                            |use alloy#dataExamples
+                            |
+                            |@dataExamples([1])
+                            |integer Id
+                            |""".stripMargin
+
+    TestUtils.runConversionTest(openapiString, expectedString)
+  }
+
+  test("example - string") {
+    val openapiString = """|openapi: '3.0.'
+                           |info:
+                           |  title: test
+                           |  version: '1.0'
+                           |paths: {}
+                           |components:
+                           |  schemas:
+                           |    Id:
+                           |      type: string
+                           |      example: something
+                           |""".stripMargin
+
+    val expectedString = """|namespace foo
+                            |
+                            |use alloy#dataExamples
+                            |
+                            |@dataExamples(["something"])
+                            |string Id
+                            |""".stripMargin
+
+    TestUtils.runConversionTest(openapiString, expectedString)
+  }
+
+  test("example - structure") {
+    val openapiString = """|openapi: '3.0.'
+                           |info:
+                           |  title: test
+                           |  version: '1.0'
+                           |paths: {}
+                           |components:
+                           |  schemas:
+                           |    User:
+                           |      type: object
+                           |      properties:
+                           |        int:
+                           |          type: integer
+                           |        str:
+                           |          type: string
+                           |        dbl:
+                           |          type: number
+                           |        lst:
+                           |          type: array
+                           |          items:
+                           |            type: integer
+                           |        bool:
+                           |          type: boolean
+                           |        struct:
+                           |          type: object
+                           |          properties:
+                           |            str:
+                           |              type: string
+                           |      example:
+                           |        int: 1
+                           |        str: Jessica Smith
+                           |        dbl: 1.1
+                           |        lst: [1, 2, 3]
+                           |        bool: true
+                           |        struct:
+                           |          str: whatever
+                           |""".stripMargin
+
+    val expectedString = """|namespace foo
+                            |
+                            |use alloy#dataExamples
+                            |
+                            |@dataExamples([
+                            |  {
+                            |    int: 1,
+                            |    str: "Jessica Smith",
+                            |    dbl: 1.1,
+                            |    lst: [1, 2, 3],
+                            |    bool: true,
+                            |    struct: { str: "whatever" }
+                            |  }
+                            |])
+                            |structure User {
+                            |  int: Integer
+                            |  str: String
+                            |  dbl: Double
+                            |  lst: Lst
+                            |  bool: Boolean
+                            |  struct: Struct
+                            |}
+                            |
+                            |structure Struct {
+                            |  str: String
+                            |}
+                            |
+                            |list Lst {
+                            |  member: Integer
+                            |}
+                            |""".stripMargin
+
+    TestUtils.runConversionTest(openapiString, expectedString)
+  }
+
+  test("example - array") {
+    val openapiString = """|openapi: '3.0.'
+                           |info:
+                           |  title: test
+                           |  version: '1.0'
+                           |paths: {}
+                           |components:
+                           |  schemas:
+                           |    a:
+                           |      type: array
+                           |      items:
+                           |        type: integer
+                           |        format: int32
+                           |      example: [1, 2, 3]
+                           |""".stripMargin
+
+    val expectedString = """|namespace foo
+                            |
+                            |use alloy#dataExamples
+                            |
+                            |@dataExamples([[1, 2, 3]])
+                            |list A {
+                            |  member: Integer
+                            |}
+                            |""".stripMargin
+
+    TestUtils.runConversionTest(openapiString, expectedString)
+  }
+
+  test("example - set") {
+    val openapiString = """|openapi: '3.0.'
+                           |info:
+                           |  title: test
+                           |  version: '1.0'
+                           |paths: {}
+                           |components:
+                           |  schemas:
+                           |    a:
+                           |      type: array
+                           |      items:
+                           |        type: integer
+                           |        format: int32
+                           |      example: [1, 2, 3]
+                           |      uniqueItems: true
+                           |""".stripMargin
+
+    val expectedString = """|namespace foo
+                            |
+                            |use alloy#dataExamples
+                            |
+                            |@uniqueItems
+                            |@dataExamples([[1, 2, 3]])
+                            |list A {
+                            |  member: Integer
+                            |}
+                            |""".stripMargin
+
+    TestUtils.runConversionTest(openapiString, expectedString)
+  }
+
+  test("example - map") {
+    val openapiString = """|openapi: '3.0.'
+                           |info:
+                           |  title: test
+                           |  version: '1.0'
+                           |paths: {}
+                           |components:
+                           |  schemas:
+                           |    m:
+                           |      type: object
+                           |      additionalProperties:
+                           |        type: string
+                           |      example:
+                           |        foo: bar
+                           |""".stripMargin
+
+    val expectedString = """|namespace foo
+                            |
+                            |use alloy#dataExamples
+                            |
+                            |@dataExamples([{
+                            |  foo: "bar"
+                            |}])
+                            |map M {
+                            |  key: String
+                            |  value: String
+                            |}
+                            |""".stripMargin
+
+    TestUtils.runConversionTest(openapiString, expectedString)
+  }
+
+  test("example - map with structure member") {
+    val openapiString = """|openapi: '3.0.'
+                           |info:
+                           |  title: test
+                           |  version: '1.0'
+                           |paths: {}
+                           |components:
+                           |  schemas:
+                           |    m:
+                           |      type: object
+                           |      additionalProperties:
+                           |        type: object
+                           |        properties:
+                           |          test:
+                           |            type: string
+                           |      example:
+                           |        foo:
+                           |          test: bar
+                           |""".stripMargin
+
+    val expectedString = """|namespace foo
+                            |
+                            |use alloy#dataExamples
+                            |
+                            |@dataExamples([{
+                            |  foo: {
+                            |    test: "bar"
+                            |  }
+                            |}])
+                            |map M {
+                            |  key: String
+                            |  value: MItem
+                            |}
+                            |
+                            |structure MItem {
+                            |  test: String
+                            |}
+                            |""".stripMargin
+
+    TestUtils.runConversionTest(openapiString, expectedString)
+  }
+}


### PR DESCRIPTION
Uses the `example` property from OpenAPI to fill in the `alloy#dataExamples` trait during the OpenAPI => Smithy conversion.

See the tests in this PR for more details.