### PR TITLE
JSON schema object with only additional properties should translate to freeform primitive

### DIFF
--- a/modules/json-schema/src/internals/Extractors.scala
+++ b/modules/json-schema/src/internals/Extractors.scala
@@ -150,6 +150,16 @@ object Extractors {
           val hints = desc.toList
           Some(hints -> PBoolean)
 
+        // M:
+        //   type: object
+        //   additionalProperties: true
+        case (obj: ObjectSchema)
+            if obj.getPropertySchemas().size() == 0 &&
+              obj.permitsAdditionalProperties() &&
+              CaseMap.unapply(obj).isEmpty =>
+          val genericHints = getGenericHints(obj)
+          Some(genericHints -> PFreeForm)
+
         case _ => None
       }
       specific.map(_.leftMap(_ ++ genericHints))

--- a/modules/json-schema/tests/src/PrimitiveSpec.scala
+++ b/modules/json-schema/tests/src/PrimitiveSpec.scala
@@ -1,3 +1,18 @@
+/* Copyright 2022 Disney Streaming
+ *
+ * Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package smithytranslate.json_schema
 
 final class PrimitiveSpec extends munit.FunSuite {

--- a/modules/json-schema/tests/src/PrimitiveSpec.scala
+++ b/modules/json-schema/tests/src/PrimitiveSpec.scala
@@ -6,7 +6,7 @@ final class PrimitiveSpec extends munit.FunSuite {
     val jsonSchString = """|{
                            |  "$id": "test.json",
                            |  "$schema": "http://json-schema.org/draft-07/schema#",
-                           |  "title": "TestMap",
+                           |  "title": "FreeForm",
                            |  "type": "object",
                            |  "additionalProperties": true
                            |}
@@ -14,7 +14,31 @@ final class PrimitiveSpec extends munit.FunSuite {
 
     val expectedString = """|namespace foo
                             |
-                            |document TestMap
+                            |document FreeForm
+                            |""".stripMargin
+
+    TestUtils.runConversionTest(jsonSchString, expectedString)
+  }
+  test("freeform document nested") {
+    val jsonSchString = """|{
+                           |  "$id": "test.json",
+                           |  "$schema": "http://json-schema.org/draft-07/schema#",
+                           |  "title": "FreeFormWrapper",
+                           |  "type": "object",
+                           |  "properties": {
+                           |    "freeform": {
+                           |       "type": "object",
+                           |       "additionalProperties": true
+                           |    }
+                           |  }
+                           |}
+                           |""".stripMargin
+
+    val expectedString = """|namespace foo
+                            |
+                            |structure FreeFormWrapper {
+                            |  freeform: Document
+                            |}
                             |""".stripMargin
 
     TestUtils.runConversionTest(jsonSchString, expectedString)

--- a/modules/json-schema/tests/src/PrimitiveSpec.scala
+++ b/modules/json-schema/tests/src/PrimitiveSpec.scala
@@ -1,0 +1,22 @@
+package smithytranslate.json_schema
+
+final class PrimitiveSpec extends munit.FunSuite {
+
+  test("freeform document") {
+    val jsonSchString = """|{
+                           |  "$id": "test.json",
+                           |  "$schema": "http://json-schema.org/draft-07/schema#",
+                           |  "title": "TestMap",
+                           |  "type": "object",
+                           |  "additionalProperties": true
+                           |}
+                           |""".stripMargin
+
+    val expectedString = """|namespace foo
+                            |
+                            |document TestMap
+                            |""".stripMargin
+
+    TestUtils.runConversionTest(jsonSchString, expectedString)
+  }
+}

--- a/modules/json-schema/tests/src/RefSpec.scala
+++ b/modules/json-schema/tests/src/RefSpec.scala
@@ -102,7 +102,12 @@ final class RefSpec extends munit.FunSuite {
                            |  },
                            |  "$defs":{
                            |    "bar": {
-                           |      "type": "object"
+                           |      "type": "object",
+                           |      "properties": {
+                           |        "baz": {
+                           |          "type": "string"
+                           |        }
+                           |      }
                            |    }
                            |  }
                            |}
@@ -115,6 +120,7 @@ final class RefSpec extends munit.FunSuite {
                             |}
                             |
                             |structure Bar {
+                            |  baz: String
                             |}
                             |""".stripMargin
 

--- a/modules/json-schema/tests/src/StructureSpec.scala
+++ b/modules/json-schema/tests/src/StructureSpec.scala
@@ -45,6 +45,26 @@ final class StructureSpec extends munit.FunSuite {
     TestUtils.runConversionTest(jsonSchString, expectedString)
   }
 
+  test("structures - constant") {
+    val jsonSchString = """|{
+                           |  "$id": "test.json",
+                           |  "$schema": "http://json-schema.org/draft-07/schema#",
+                           |  "title": "Constant",
+                           |  "type": "object",
+                           |  "additionalProperties": false
+                           |}
+                           |""".stripMargin
+
+    val expectedString = """|namespace foo
+                            |
+                            |structure Constant {
+                            |}
+                            |""".stripMargin
+
+    TestUtils.runConversionTest(jsonSchString, expectedString)
+
+  }
+
   test("structures - nested") {
     val jsonSchString = """|{
                            |  "$id": "test.json",


### PR DESCRIPTION
The following JSON schema should translate to a Smithy `document` primitive.
```json
{
  "$id": "test.json",
  "$schema": "http://json-schema.org/draft-07/schema#",
  "title": "FreeForm",
  "type": "object",
  "additionalProperties": true
}
```

The OpenApi translation already converts these types of definitions to freeform documents. See https://github.com/disneystreaming/smithy-translate/blob/v0.3.5/modules/openapi/src/internals/Extractors.scala#L46-L57