### PR TITLE
fix so proto files are output to correct folders

### DIFF
--- a/modules/proto/core/src/smithyproto/proto3/Namespacing.scala
+++ b/modules/proto/core/src/smithyproto/proto3/Namespacing.scala
@@ -32,11 +32,8 @@ object Namespacing {
     val parts = ns.split("\\.").toList
     if (parts.size == 0) {
       Fqn(None, "definitions") // should not happen
-    } else if (parts.size == 1) {
-      Fqn(Some(parts), "definitions")
     } else {
-      val last = parts.last
-      Fqn(Some(parts.init), last)
+      Fqn(Some(parts), "definitions")
     }
   }
 }

--- a/modules/proto/core/tests/src/CompilerRendererSuite.scala
+++ b/modules/proto/core/tests/src/CompilerRendererSuite.scala
@@ -42,7 +42,7 @@ class CompilerRendererSuite extends FunSuite {
                       |  }
                       |}
                       |""".stripMargin
-    convertCheck(source, Map("com/example.proto" -> expected))
+    convertCheck(source, Map("com/example/definitions.proto" -> expected))
   }
 
   test("@protoInlinedOneOf union - used within only one data structure") {
@@ -79,7 +79,7 @@ class CompilerRendererSuite extends FunSuite {
                       |  string other = 4;
                       |}
                       |""".stripMargin
-    convertCheck(source, Map("com/example.proto" -> expected))
+    convertCheck(source, Map("com/example/definitions.proto" -> expected))
   }
 
   test(
@@ -146,7 +146,7 @@ class CompilerRendererSuite extends FunSuite {
                     |  google.protobuf.Any value = 1;
                     |}
                     |""".stripMargin
-    convertCheck(source, Map("com/example.proto" -> expected))
+    convertCheck(source, Map("com/example/definitions.proto" -> expected))
   }
 
   test("top level - string") {
@@ -162,7 +162,7 @@ class CompilerRendererSuite extends FunSuite {
                     |  string value = 1;
                     |}
                     |""".stripMargin
-    convertCheck(source, Map("com/example.proto" -> expected))
+    convertCheck(source, Map("com/example/definitions.proto" -> expected))
   }
 
   test("top level - structure") {
@@ -181,7 +181,7 @@ class CompilerRendererSuite extends FunSuite {
                     |  string value = 1;
                     |}
                     |""".stripMargin
-    convertCheck(source, Map("com/example.proto" -> expected))
+    convertCheck(source, Map("com/example/definitions.proto" -> expected))
   }
 
   test("top level - int") {
@@ -197,7 +197,7 @@ class CompilerRendererSuite extends FunSuite {
                     |  int32 value = 1;
                     |}
                     |""".stripMargin
-    convertCheck(source, Map("com/example.proto" -> expected))
+    convertCheck(source, Map("com/example/definitions.proto" -> expected))
   }
 
   test("top level - long") {
@@ -213,7 +213,7 @@ class CompilerRendererSuite extends FunSuite {
                     |  int64 value = 1;
                     |}
                     |""".stripMargin
-    convertCheck(source, Map("com/example.proto" -> expected))
+    convertCheck(source, Map("com/example/definitions.proto" -> expected))
   }
 
   test("top level - double") {
@@ -230,7 +230,7 @@ class CompilerRendererSuite extends FunSuite {
                     |}
                     |""".stripMargin
 
-    convertCheck(source, Map("com/example.proto" -> expected))
+    convertCheck(source, Map("com/example/definitions.proto" -> expected))
   }
 
   test("top level - float") {
@@ -246,7 +246,7 @@ class CompilerRendererSuite extends FunSuite {
                     |  float value = 1;
                     |}
                     |""".stripMargin
-    convertCheck(source, Map("com/example.proto" -> expected))
+    convertCheck(source, Map("com/example/definitions.proto" -> expected))
 
   }
 
@@ -263,7 +263,7 @@ class CompilerRendererSuite extends FunSuite {
                     |  int32 value = 1;
                     |}
                     |""".stripMargin
-    convertCheck(source, Map("com/example.proto" -> expected))
+    convertCheck(source, Map("com/example/definitions.proto" -> expected))
   }
 
   test("top level - bool") {
@@ -279,7 +279,7 @@ class CompilerRendererSuite extends FunSuite {
                     |  bool value = 1;
                     |}
                     |""".stripMargin
-    convertCheck(source, Map("com/example.proto" -> expected))
+    convertCheck(source, Map("com/example/definitions.proto" -> expected))
   }
 
   test("top level - bytes") {
@@ -295,7 +295,7 @@ class CompilerRendererSuite extends FunSuite {
                     |  bytes value = 1;
                     |}
                     |""".stripMargin
-    convertCheck(source, Map("com/example.proto" -> someBlob))
+    convertCheck(source, Map("com/example/definitions.proto" -> someBlob))
   }
 
   test("top level - big integer") {
@@ -313,7 +313,7 @@ class CompilerRendererSuite extends FunSuite {
                     |  smithytranslate.BigInteger value = 1;
                     |}
                     |""".stripMargin
-    convertCheck(source, Map("com/example.proto" -> expected))
+    convertCheck(source, Map("com/example/definitions.proto" -> expected))
   }
 
   test("top level - big decimal") {
@@ -331,7 +331,10 @@ class CompilerRendererSuite extends FunSuite {
                     |  smithytranslate.BigDecimal value = 1;
                     |}
                     |""".stripMargin
-    convertWithApiCheck(source, Map("com/example.proto" -> expected))
+    convertWithApiCheck(
+      source,
+      Map("com/example/definitions.proto" -> expected)
+    )
   }
 
   test("top level - timestamp") {
@@ -349,7 +352,10 @@ class CompilerRendererSuite extends FunSuite {
                     |  smithytranslate.Timestamp value = 1;
                     |}
                     |""".stripMargin
-    convertWithApiCheck(source, Map("com/example.proto" -> expected))
+    convertWithApiCheck(
+      source,
+      Map("com/example/definitions.proto" -> expected)
+    )
   }
 
   test("proto top-level deprecated") {
@@ -368,7 +374,7 @@ class CompilerRendererSuite extends FunSuite {
                       |  string value = 1 [deprecated = true];
                       |}
                       |""".stripMargin
-    convertCheck(source, Map("another/namespace.proto" -> expected))
+    convertCheck(source, Map("another/namespace/definitions.proto" -> expected))
   }
 
   test("proto structure deprecated") {
@@ -390,7 +396,7 @@ class CompilerRendererSuite extends FunSuite {
                       |  string value = 1 [deprecated = true];
                       |}
                       |""".stripMargin
-    convertCheck(source, Map("another/namespace.proto" -> expected))
+    convertCheck(source, Map("another/namespace/definitions.proto" -> expected))
   }
 
   test("protoNumType") {
@@ -498,7 +504,7 @@ class CompilerRendererSuite extends FunSuite {
                       |}""".stripMargin
     convertCheck(
       source,
-      Map("com/example.proto" -> expected)
+      Map("com/example/definitions.proto" -> expected)
     )
   }
 
@@ -525,7 +531,7 @@ class CompilerRendererSuite extends FunSuite {
                     |  map<string, google.protobuf.StringValue> object = 1;
                     |}
                     |""".stripMargin
-    convertCheck(source, Map("com/example.proto" -> expected))
+    convertCheck(source, Map("com/example/definitions.proto" -> expected))
   }
 
   test("inlined maps message") {
@@ -557,7 +563,7 @@ class CompilerRendererSuite extends FunSuite {
                       |  map<string, com.example.MapItem> values = 1;
                       |}
                       |""".stripMargin
-    convertCheck(source, Map("com/example.proto" -> expected))
+    convertCheck(source, Map("com/example/definitions.proto" -> expected))
   }
 
   test("inlined maps") {
@@ -580,7 +586,7 @@ class CompilerRendererSuite extends FunSuite {
                     |  map<string, int32> strings = 1;
                     |}
                     |""".stripMargin
-    convertCheck(source, Map("com/example.proto" -> expected))
+    convertCheck(source, Map("com/example/definitions.proto" -> expected))
   }
 
   test("inlined lists") {
@@ -602,7 +608,7 @@ class CompilerRendererSuite extends FunSuite {
                     |  repeated string strings = 1;
                     |}
                     |""".stripMargin
-    convertCheck(source, Map("com/example.proto" -> expected))
+    convertCheck(source, Map("com/example/definitions.proto" -> expected))
   }
 
   test("inlined sparse lists") {
@@ -627,7 +633,7 @@ class CompilerRendererSuite extends FunSuite {
                     |  repeated google.protobuf.StringValue strings = 1;
                     |}
                     |""".stripMargin
-    convertCheck(source, Map("com/example.proto" -> expected))
+    convertCheck(source, Map("com/example/definitions.proto" -> expected))
   }
 
   test("inlined lists message") {
@@ -659,7 +665,7 @@ class CompilerRendererSuite extends FunSuite {
                    |  repeated com.example.ListItem strings = 1;
                    |}
                    |""".stripMargin
-    convertCheck(source, Map("com/example.proto" -> expected))
+    convertCheck(source, Map("com/example/definitions.proto" -> expected))
 
   }
 
@@ -703,7 +709,7 @@ class CompilerRendererSuite extends FunSuite {
                       |message Unions {
                       |  repeated com.example.UnionStruct values = 1;
                       |}""".stripMargin
-    convertCheck(source, Map("com/example.proto" -> expected))
+    convertCheck(source, Map("com/example/definitions.proto" -> expected))
   }
 
   test("transitive structure with protoEnabled") {
@@ -1066,7 +1072,10 @@ class CompilerRendererSuite extends FunSuite {
                       |message Two {
                       |  avoid.cyclic.in.namespace.One one = 1;
                       |}""".stripMargin
-    convertCheck(source, Map("avoid/cyclic/in/namespace.proto" -> expected))
+    convertCheck(
+      source,
+      Map("avoid/cyclic/in/namespace/definitions.proto" -> expected)
+    )
   }
 
   test("multiple namespaces") {
@@ -1085,8 +1094,8 @@ class CompilerRendererSuite extends FunSuite {
     convertChecks(
       Map("ns1.smithy" -> src("ns1"), "ns2.smithy" -> src("ns2")),
       Map(
-        "com/ns1.proto" -> expected("ns1"),
-        "com/ns2.proto" -> expected("ns2")
+        "com/ns1/definitions.proto" -> expected("ns1"),
+        "com/ns2/definitions.proto" -> expected("ns2")
       )
     )
   }
@@ -1116,7 +1125,7 @@ class CompilerRendererSuite extends FunSuite {
                       |  string value = 1;
                       |}
                       |""".stripMargin
-    convertCheck(source, Map("another/namespace.proto" -> expected))
+    convertCheck(source, Map("another/namespace/definitions.proto" -> expected))
   }
 
   /** Perform the same check as convertCheck but include the smithytranslate

--- a/modules/proto/core/tests/src/CompilerSuite.scala
+++ b/modules/proto/core/tests/src/CompilerSuite.scala
@@ -55,7 +55,8 @@ class CompilerSuite extends FunSuite {
       OutputFile(
         List(
           "com",
-          "example.proto"
+          "example",
+          "definitions.proto"
         ),
         CompilationUnit(
           Some(
@@ -75,26 +76,38 @@ class CompilerSuite extends FunSuite {
   }
 
   test("correctly choose file name - all caps") {
-    namespaceTest("com.EXAMPLE", List("com", "example.proto"))
+    namespaceTest("com.EXAMPLE", List("com", "EXAMPLE", "definitions.proto"))
   }
 
   test("correctly choose file name - underscore") {
-    namespaceTest("com.some_example", List("com", "some_example.proto"))
+    namespaceTest(
+      "com.some_example",
+      List("com", "some_example", "definitions.proto")
+    )
   }
 
   test("correctly choose file name - leading underscore") {
-    namespaceTest("com._example", List("com", "_example.proto"))
-    namespaceTest("com._EXAMPLE", List("com", "_example.proto"))
-    namespaceTest("com._Example", List("com", "_example.proto"))
+    namespaceTest("com._example", List("com", "_example", "definitions.proto"))
+    namespaceTest("com._EXAMPLE", List("com", "_EXAMPLE", "definitions.proto"))
+    namespaceTest("com._Example", List("com", "_Example", "definitions.proto"))
   }
 
   test("correctly choose file name - underscore and caps") {
-    namespaceTest("com.some_EXAMPLE", List("com", "some_example.proto"))
-    namespaceTest("com.SOME_EXAMPLE", List("com", "some_example.proto"))
-    namespaceTest("com.Some_Example", List("com", "some_example.proto"))
+    namespaceTest(
+      "com.some_EXAMPLE",
+      List("com", "some_EXAMPLE", "definitions.proto")
+    )
+    namespaceTest(
+      "com.SOME_EXAMPLE",
+      List("com", "SOME_EXAMPLE", "definitions.proto")
+    )
+    namespaceTest(
+      "com.Some_Example",
+      List("com", "Some_Example", "definitions.proto")
+    )
     namespaceTest(
       "com.Some_OTHER_Example",
-      List("com", "some_other_example.proto")
+      List("com", "Some_OTHER_Example", "definitions.proto")
     )
   }
 

--- a/modules/proto/examples/protobuf/demo/common/definitions.proto
+++ b/modules/proto/examples/protobuf/demo/common/definitions.proto
@@ -1,0 +1,8 @@
+syntax = "proto3";
+
+package demo.common;
+
+enum Language {
+  FRENCH = 0;
+  ENGLISH = 1;
+}

--- a/modules/proto/examples/protobuf/demo/definitions.proto
+++ b/modules/proto/examples/protobuf/demo/definitions.proto
@@ -4,6 +4,8 @@ package demo;
 
 import "google/protobuf/empty.proto";
 
+import "demo/common/definitions.proto";
+
 import "google/protobuf/wrappers.proto";
 
 import "smithytranslate/definitions.proto";
@@ -13,15 +15,10 @@ service Hello {
   rpc Greet(google.protobuf.Empty) returns (demo.HelloResponse);
 }
 
-enum Language {
-  FRENCH = 0;
-  ENGLISH = 1;
-}
-
 message HelloRequest {
   reserved 3;
   string name = 1;
-  demo.Language lang = 2;
+  demo.common.Language lang = 2;
   int32 requiredInt = 4;
   google.protobuf.Int32Value int = 5;
   smithytranslate.UUID id = 6;

--- a/modules/proto/examples/smithy/common.smithy
+++ b/modules/proto/examples/smithy/common.smithy
@@ -1,0 +1,13 @@
+$version: "2"
+
+namespace demo.common
+
+use alloy.proto#protoIndex
+
+// protoindex is not necessary , this is just for demo purposes
+enum Language{
+    @protoIndex(0)
+    FRENCH
+    @protoIndex(1)
+    ENGLISH
+}

--- a/modules/proto/examples/smithy/demo.smithy
+++ b/modules/proto/examples/smithy/demo.smithy
@@ -8,6 +8,7 @@ use alloy.proto#protoEnabled
 use alloy.proto#protoReservedFields
 use alloy.proto#protoNumType
 use alloy#UUID
+use demo.common#Language
 
 @protoEnabled
 service Hello {
@@ -22,14 +23,6 @@ operation SayHello {
 
 operation Greet {
   output: HelloResponse
-}
-
-// protoindex is not necessary , this is just for demo purposes
-enum Language{
-    @protoIndex(0)
-    FRENCH
-    @protoIndex(1)
-    ENGLISH
 }
 
 @protoReservedFields([{number: 3}])


### PR DESCRIPTION
Prior, the files for a namespace like `foo.bar.baz` were output to `/foo/bar/baz.proto` however, they should be output to `/foo/bar/baz/definitions.proto` as to avoid collisions and generally unexpected behavior.