### PR TITLE
Dumo pre-configured smithy-build.json after translation

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -1,5 +1,6 @@
 import $ivy.`com.lihaoyi::mill-contrib-bloop:`
 import $ivy.`com.lihaoyi::mill-contrib-scalapblib:`
+import $ivy.`com.lihaoyi::mill-contrib-buildinfo:`
 import $ivy.`io.chris-kipp::mill-ci-release::0.1.9`
 import $ivy.`com.lewisjkl::header-mill-plugin::0.0.2`
 
@@ -9,6 +10,7 @@ import io.kipp.mill.ci.release.CiReleaseModule
 import io.kipp.mill.ci.release.SonatypeHost
 import mill._
 import mill.contrib.scalapblib.ScalaPBModule
+import mill.contrib.buildinfo
 import mill.define.Sources
 import mill.define.Task
 import mill.modules.Assembly
@@ -176,12 +178,20 @@ object openapi extends BaseScalaModule {
   }
 }
 
-object cli extends BaseScalaModule {
+object cli extends BaseScalaModule with buildinfo.BuildInfo {
   def ivyDeps = Agg(
     Deps.decline,
     Deps.coursier,
     Deps.lihaoyi.oslib,
+    Deps.lihaoyi.ujson,
     Deps.smithy.build
+  )
+
+  def buildInfoPackageName = Some("smithytranslate.cli.internal")
+
+  def buildInfoMembers = Map(
+    "alloyVersion" -> Deps.alloy.alloyVersion,
+    "cliVersion" -> publishVersion().toString
   )
 
   def moduleDeps = Seq(openapi, proto.core, `json-schema`, formatter.jvm)
@@ -400,8 +410,9 @@ object transitive extends BaseScalaModule {
 
 object Deps {
   object alloy {
+    val alloyVersion = "0.2.3"
     val core =
-      ivy"com.disneystreaming.alloy:alloy-core:0.2.3"
+      ivy"com.disneystreaming.alloy:alloy-core:$alloyVersion"
   }
   object circe {
     val jawn = ivy"io.circe::circe-jawn:0.14.5"
@@ -431,6 +442,7 @@ object Deps {
   val decline = ivy"com.monovore::decline:2.4.1"
   object lihaoyi {
     val oslib = ivy"com.lihaoyi::os-lib:0.9.1"
+    val ujson = ivy"com.lihaoyi::ujson:3.1.2"
   }
 
   val munit = ivy"org.scalameta::munit:0.7.29"

--- a/modules/cli/src/Main.scala
+++ b/modules/cli/src/Main.scala
@@ -42,11 +42,17 @@ object Main
             .orElse(OpenAPIJsonSchemaOpts.jsonSchemaToSmithy)
             .orElse(FormatterOpts.format)
         cli map {
-          case OpenApiTranslate(opts) if opts.isOpenapi =>
-            OpenApi.runOpenApi(opts)
-          case OpenApiTranslate(opts) => OpenApi.runJsonSchema(opts)
-          case ProtoTranslate(opts)   => Proto.runFromCli(opts)
-          case Format(opts)           => Formatter.run(opts)
+          case OpenApiTranslate(opts) =>
+            if (opts.isOpenapi)
+              OpenApi.runOpenApi(opts)
+            else
+              OpenApi.runJsonSchema(opts)
+            SmithyBuildJsonWriter.writeDefault(opts.outputPath, opts.force)
+
+          case ProtoTranslate(opts) =>
+            Proto.runFromCli(opts)
+
+          case Format(opts) => Formatter.run(opts)
         }
       }
     )

--- a/modules/cli/src/SmithyBuildJsonWriter.scala
+++ b/modules/cli/src/SmithyBuildJsonWriter.scala
@@ -1,0 +1,32 @@
+package smithytranslate.cli
+
+import internal.BuildInfo
+
+object SmithyBuildJsonWriter {
+  def writeDefault(dest: os.Path, force: Boolean = false) = {
+    val contents = ujson.Obj(
+      "maven" -> ujson.Obj(
+        "dependencies" -> ujson.Arr(
+          ujson.Str(
+            s"com.disneystreaming.alloy:alloy-core:${BuildInfo.alloyVersion}"
+          ),
+          ujson.Str(
+            s"com.disneystreaming.smithy:smithytranslate-traits:${BuildInfo.cliVersion}"
+          )
+        )
+      )
+    )
+
+    val destPath = dest / "smithy-build.json"
+
+    if (force)
+      os.write.over(destPath, contents)
+    else if (destPath.toIO.exists() && !force)
+      System.err.println(
+        s"Destination [$destPath] already exist - to overwrite, please use --force flag"
+      )
+    else
+      os.write(destPath, contents)
+
+  }
+}

--- a/modules/cli/src/SmithyBuildJsonWriter.scala
+++ b/modules/cli/src/SmithyBuildJsonWriter.scala
@@ -1,3 +1,18 @@
+/* Copyright 2022 Disney Streaming
+ *
+ * Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package smithytranslate.cli
 
 import internal.BuildInfo

--- a/modules/cli/src/opts/OpenAPIJsonSchemaOpts.scala
+++ b/modules/cli/src/opts/OpenAPIJsonSchemaOpts.scala
@@ -28,7 +28,8 @@ final case class OpenAPIJsonSchemaOpts(
     failOnValidationErrors: Boolean,
     useEnumTraitSyntax: Boolean,
     outputJson: Boolean,
-    debug: Boolean
+    debug: Boolean,
+    force: Boolean
 )
 
 object OpenAPIJsonSchemaOpts {
@@ -67,18 +68,25 @@ object OpenAPIJsonSchemaOpts {
     )
     .orFalse
 
+  private val force: Opts[Boolean] = Opts
+    .flag(
+      "force",
+      help = "Force overwrite smithy-build.json file if it's present"
+    )
+    .orFalse
+
   private def getOpts(isOpenapi: Boolean) =
     (
+      Opts(isOpenapi),
       CommonOpts.sources,
       CommonOpts.outputDirectory,
       verboseNames,
       failOnValidationErrors,
       useEnumTraitSyntax,
       outputJson,
-      debug
-    ).mapN(
-      OpenAPIJsonSchemaOpts.apply(isOpenapi, _, _, _, _, _, _, _)
-    )
+      debug,
+      force
+    ).mapN(OpenAPIJsonSchemaOpts.apply)
 
   private val openApiToSmithyCmd = Command(
     name = "openapi-to-smithy",

--- a/modules/cli/src/opts/ProtoOpts.scala
+++ b/modules/cli/src/opts/ProtoOpts.scala
@@ -24,8 +24,7 @@ case class ProtoOpts(
     inputFiles: NonEmptyList[os.Path],
     outputPath: os.Path,
     deps: List[String],
-    repositories: List[String],
-    force: Boolean
+    repositories: List[String]
 )
 
 object ProtoOpts {
@@ -45,15 +44,8 @@ object ProtoOpts {
       )
       .orEmpty
 
-  private val force: Opts[Boolean] = Opts
-    .flag(
-      "force",
-      help = "Force overwrite smithy-build.json file if it's present"
-    )
-    .orFalse
-
   private val opts =
-    (CommonOpts.sources, CommonOpts.outputDirectory, deps, repositories, force)
+    (CommonOpts.sources, CommonOpts.outputDirectory, deps, repositories)
       .mapN(ProtoOpts.apply)
 
   private val smithyToProtoCmd = Command(

--- a/modules/cli/src/opts/ProtoOpts.scala
+++ b/modules/cli/src/opts/ProtoOpts.scala
@@ -24,7 +24,8 @@ case class ProtoOpts(
     inputFiles: NonEmptyList[os.Path],
     outputPath: os.Path,
     deps: List[String],
-    repositories: List[String]
+    repositories: List[String],
+    force: Boolean
 )
 
 object ProtoOpts {
@@ -44,10 +45,16 @@ object ProtoOpts {
       )
       .orEmpty
 
-  private val opts =
-    (CommonOpts.sources, CommonOpts.outputDirectory, deps, repositories).mapN(
-      ProtoOpts(_, _, _, _)
+  private val force: Opts[Boolean] = Opts
+    .flag(
+      "force",
+      help = "Force overwrite smithy-build.json file if it's present"
     )
+    .orFalse
+
+  private val opts =
+    (CommonOpts.sources, CommonOpts.outputDirectory, deps, repositories, force)
+      .mapN(ProtoOpts.apply)
 
   private val smithyToProtoCmd = Command(
     name = "smithy-to-proto",


### PR DESCRIPTION
So that when you open your editor in the folder, you don't get missing definitions for alloy and smithytranslate#contentType for example