### PR TITLE
Render dummy description in external docs for openapi->smithy

### DIFF
--- a/modules/openapi/src/internals/Hint.scala
+++ b/modules/openapi/src/internals/Hint.scala
@@ -46,6 +46,6 @@ object Hint {
   case class TargetLocation(str: String) extends Hint
   case class JsonName(name: String) extends Hint
   case class Examples(value: List[Node]) extends Hint
-  case class ExternalDocs(description: String, url: String) extends Hint
+  case class ExternalDocs(description: Option[String], url: String) extends Hint
 }
 // format: on

--- a/modules/openapi/src/internals/IModelToSmithy.scala
+++ b/modules/openapi/src/internals/IModelToSmithy.scala
@@ -307,7 +307,12 @@ final class IModelToSmithy(useEnumTraitSyntax: Boolean)
     case Hint.Nullable                => List(new NullableTrait())
     case Hint.JsonName(value)         => List(new JsonNameTrait(value))
     case Hint.ExternalDocs(desc, url) =>
-      List(ExternalDocumentationTrait.builder().addUrl(desc, url).build())
+      List(
+        ExternalDocumentationTrait
+          .builder()
+          .addUrl(desc.getOrElse("no description"), url)
+          .build()
+      )
     case Hint.Examples(examples) =>
       val trt = DataExamplesTrait.builder
       examples.foreach(ex =>

--- a/modules/openapi/src/internals/IModelToSmithy.scala
+++ b/modules/openapi/src/internals/IModelToSmithy.scala
@@ -310,7 +310,7 @@ final class IModelToSmithy(useEnumTraitSyntax: Boolean)
       List(
         ExternalDocumentationTrait
           .builder()
-          .addUrl(desc.getOrElse("no description"), url)
+          .addUrl(desc.getOrElse("documentation"), url)
           .build()
       )
     case Hint.Examples(examples) =>

--- a/modules/openapi/src/internals/OpenApiToIModel.scala
+++ b/modules/openapi/src/internals/OpenApiToIModel.scala
@@ -373,7 +373,7 @@ private class OpenApiToIModel[F[_]: Parallel: TellShape: TellError](
     val exts = GetExtensions.from(openApi)
     val infoExts = GetExtensions.from(openApi.getInfo())
     val externalDocs = Option(openApi.getExternalDocs()).map(e =>
-      Hint.ExternalDocs(e.getDescription(), e.getUrl())
+      Hint.ExternalDocs(Option(e.getDescription()), e.getUrl())
     )
     val service = ServiceDef(
       DefId(
@@ -575,7 +575,7 @@ private class OpenApiToIModel[F[_]: Parallel: TellShape: TellError](
       schema: Schema[_]
   ): Option[Hint.ExternalDocs] =
     Option(schema.getExternalDocs())
-      .map(e => Hint.ExternalDocs(e.getDescription(), e.getUrl()))
+      .map(e => Hint.ExternalDocs(Option(e.getDescription()), e.getUrl()))
 
   /*
    * The goal here is to match one layer of "Schema[_]" and

--- a/modules/openapi/src/internals/ParseOperations.scala
+++ b/modules/openapi/src/internals/ParseOperations.scala
@@ -183,7 +183,7 @@ private class ParseOperationsImpl(
       getSecurityHint(securitySchemes, opInfo, hasGlobalSecurity)
     val descHint = Option(op.getDescription()).map(Hint.Description).toList
     val exDocs = Option(opInfo.op.getExternalDocs()).map(e =>
-      Hint.ExternalDocs(e.getDescription(), e.getUrl())
+      Hint.ExternalDocs(Option(e.getDescription()), e.getUrl())
     )
     val hints =
       GetExtensions.from(opInfo.op) ++ securityHint ++ descHint ++ exDocs


### PR DESCRIPTION
Closes #162 

There is indeed no other way but providing a dummy description in here, which is a bit annoying.

