### PR TITLE
Allow empty enum

### DIFF
--- a/modules/formatter/src/ast/shapes.scala
+++ b/modules/formatter/src/ast/shapes.scala
@@ -290,7 +290,7 @@ object shapes {
 
     case class EnumShapeMembers(
         whitespace: Whitespace,
-        members: NonEmptyList[
+        members: List[
           (TraitStatements, Identifier, Option[ValueAssignment], Whitespace)
         ]
     )

--- a/modules/formatter/src/parsers/ShapeParser.scala
+++ b/modules/formatter/src/parsers/ShapeParser.scala
@@ -109,8 +109,12 @@ object ShapeParser {
         SimpleShapeStatement(simpleTypeName, b, mixin)
     }
 
+  /** This behaves a little bit differently from the spec because the spec does
+    * not allow for empty enum, but we'll support that because with mixins this
+    * becomes a valid possibility.
+    */
   val enum_shape_members: Parser[EnumShapeMembers] =
-    (openCurly *> ws.with1 ~ (trait_statements.with1 ~ identifier ~ value_assigments.backtrack.? ~ ws).rep <* closeCurly)
+    (openCurly *> ws ~ (trait_statements.with1 ~ identifier ~ value_assigments.backtrack.? ~ ws).rep0 <* closeCurly)
       .map { case (ws, members) =>
         EnumShapeMembers(
           ws,

--- a/modules/formatter/tests/src/FormatterSpec.scala
+++ b/modules/formatter/tests/src/FormatterSpec.scala
@@ -1053,4 +1053,30 @@ final class FormatterSpec extends munit.FunSuite {
                       |""".stripMargin
     formatTest(src, expected)
   }
+
+  test("#171 enums with mixin") {
+    val src = """|$version: "2"
+                 |namespace demo
+                 |
+                 |@mixin enum X {
+                 |  A
+                 |}
+                 |
+                 |enum Y with [X] {}
+                 |""".stripMargin
+    val expected = """|$version: "2"
+                      |
+                      |namespace demo
+                      |
+                      |@mixin
+                      |enum X {
+                      |    A
+                      |}
+                      |
+                      |enum Y with [X] {
+                      |
+                      |}
+                      |""".stripMargin
+    formatTest(src, expected)
+  }
 }


### PR DESCRIPTION
The IDL says: `"{" [WS] 1*(EnumShapeMember [WS]) "}"` which means atleast one member is required. In this case, I've allowed the implementation to drift from the spec because I don't think the parser should be validating business rules like that. From our point of view, it's hard to tell if the enum is empty when mixins could be adding members or not.

Fixes #171 