### PR TITLE
JSON Schema Optional id Field

### DIFF
--- a/modules/json-schema/src/internals/JsonSchemaToIModel.scala
+++ b/modules/json-schema/src/internals/JsonSchemaToIModel.scala
@@ -69,7 +69,10 @@ private class JsonSchemaToIModel[F[_]: Parallel: TellShape: TellError](
   implicit val F: Monad[F] = Parallel[F].monad
 
   private val CaseRef =
-    new Extractors.JsonSchemaCaseRefBuilder(jsonSchema.getId(), namespace) {}
+    new Extractors.JsonSchemaCaseRefBuilder(
+      Option(jsonSchema.getId()),
+      namespace
+    ) {}
 
   private val allSchemas: Vector[Local] = {
     val schemaNameSegment =

--- a/modules/json-schema/tests/src/RefSpec.scala
+++ b/modules/json-schema/tests/src/RefSpec.scala
@@ -254,4 +254,38 @@ final class RefSpec extends munit.FunSuite {
 
     TestUtils.runConversionTest(jsonSchString, expectedString)
   }
+
+  test("schema with no id") {
+    val jsonSchString = """|{
+                           |  "$schema": "http://json-schema.org/draft-07/schema#",
+                           |  "title": "Person",
+                           |  "type": "object",
+                           |  "properties": {
+                           |    "firstName": {
+                           |      "$ref": "#/$defs/name"
+                           |    },
+                           |    "lastName": {
+                           |      "$ref": "#/$defs/name"
+                           |    }
+                           |  },
+                           |  "$defs":{
+                           |    "name": {
+                           |      "type": "string"
+                           |    }
+                           |  }
+                           |}
+                           |""".stripMargin
+
+    val expectedString = """|namespace foo
+                            |
+                            |structure Person {
+                            | firstName: Name,
+                            | lastName: Name
+                            |}
+                            |
+                            |string Name
+                            |""".stripMargin
+
+    TestUtils.runConversionTest(jsonSchString, expectedString)
+  }
 }


### PR DESCRIPTION
Per the JSON Schema spec, the ID field [is optional](https://json-schema.org/draft/2020-12/json-schema-core#name-the-id-keyword).