### PR TITLE
Support definitions for older json schema versions

### DIFF
--- a/modules/json-schema/src/internals/JsonSchemaToIModel.scala
+++ b/modules/json-schema/src/internals/JsonSchemaToIModel.scala
@@ -80,9 +80,9 @@ private class JsonSchemaToIModel[F[_]: Parallel: TellShape: TellError](
     val schemaName = Name(schemaNameSegment)
 
     // Computing schemas under the $defs field, if it exists.
-    def $defSchemas = {
+    def $defSchemas: String => Vector[Local] = { name =>
       val defsObject = rawJson.asObject
-        .flatMap(_.apply("$defs"))
+        .flatMap(_.apply(name))
         .flatMap(_.asObject)
 
       val allDefs = defsObject.toVector
@@ -92,14 +92,14 @@ private class JsonSchemaToIModel[F[_]: Parallel: TellShape: TellError](
       allDefs
         .flatMap { case (key, value) =>
           val topLevelJson = Json.fromJsonObject {
-            value.add("$defs", Json.fromJsonObject(defsObject.get))
+            value.add(name, Json.fromJsonObject(defsObject.get))
           }
 
           val defSchema = LoadSchema(new JSONObject(topLevelJson.noSpaces))
 
           val defSchemaName =
             Name(
-              Segment.Arbitrary(CIString("$defs")),
+              Segment.Arbitrary(CIString(name)),
               Segment.Derived(CIString(key))
             )
           Vector(
@@ -113,7 +113,7 @@ private class JsonSchemaToIModel[F[_]: Parallel: TellShape: TellError](
     val topLevelLocal =
       Local(schemaName, jsonSchema, rawJson).addHints(List(Hint.TopLevel))
 
-    topLevelLocal +: $defSchemas
+    topLevelLocal +: ($defSchemas("$defs") ++ $defSchemas("definitions"))
   }
 
   /** Refolds the schema, aggregating found definitions in Tell.

--- a/modules/json-schema/src/internals/JsonSchemaToIModel.scala
+++ b/modules/json-schema/src/internals/JsonSchemaToIModel.scala
@@ -80,7 +80,7 @@ private class JsonSchemaToIModel[F[_]: Parallel: TellShape: TellError](
     val schemaName = Name(schemaNameSegment)
 
     // Computing schemas under the $defs field, if it exists.
-    def $defSchemas: String => Vector[Local] = { name =>
+    def $defSchemas(name: String): Vector[Local] = {
       val defsObject = rawJson.asObject
         .flatMap(_.apply(name))
         .flatMap(_.asObject)

--- a/modules/json-schema/tests/src/RefSpec.scala
+++ b/modules/json-schema/tests/src/RefSpec.scala
@@ -288,4 +288,38 @@ final class RefSpec extends munit.FunSuite {
 
     TestUtils.runConversionTest(jsonSchString, expectedString)
   }
+
+  test("schema with definitions rather than $defs") {
+    val jsonSchString = """|{
+                           |  "$schema": "http://json-schema.org/draft-07/schema#",
+                           |  "title": "Person",
+                           |  "type": "object",
+                           |  "properties": {
+                           |    "firstName": {
+                           |      "$ref": "#/definitions/name"
+                           |    },
+                           |    "lastName": {
+                           |      "$ref": "#/definitions/name"
+                           |    }
+                           |  },
+                           |  "definitions":{
+                           |    "name": {
+                           |      "type": "string"
+                           |    }
+                           |  }
+                           |}
+                           |""".stripMargin
+
+    val expectedString = """|namespace foo
+                            |
+                            |structure Person {
+                            | firstName: Name,
+                            | lastName: Name
+                            |}
+                            |
+                            |string Name
+                            |""".stripMargin
+
+    TestUtils.runConversionTest(jsonSchString, expectedString)
+  }
 }


### PR DESCRIPTION
In older versions of json schema, `definitions` was used instead of `$defs`