### PR TITLE
Disable validation of output smithy files by default.

### DIFF
--- a/modules/cli/src/opts/OpenAPIJsonSchemaOpts.scala
+++ b/modules/cli/src/opts/OpenAPIJsonSchemaOpts.scala
@@ -25,7 +25,8 @@ final case class OpenAPIJsonSchemaOpts(
     inputFiles: NonEmptyList[os.Path],
     outputPath: os.Path,
     useVerboseNames: Boolean,
-    failOnValidationErrors: Boolean,
+    failOnInputValidationErrors: Boolean,
+    failOnOutputValidationErrors: Boolean,
     useEnumTraitSyntax: Boolean,
     outputJson: Boolean,
     debug: Boolean,
@@ -40,10 +41,18 @@ object OpenAPIJsonSchemaOpts {
       "If set, names of shapes not be simplified and will be as verbose as possible"
     )
     .orFalse
-  private val failOnValidationErrors = Opts
+
+  private val failOnInputValidationErrors = Opts
     .flag(
-      "failOnValidationErrors",
-      "If set, abort the conversion if any specs contains a validation error"
+      "failOnInputValidationErrors",
+      "If set, abort the conversion if any input specs contains a validation error"
+    )
+    .orFalse
+
+  private val failOnOutputValidationErrors = Opts
+    .flag(
+      "failOnOutputValidationErrors",
+      "If set, abort the conversion if any produced smithy spec contains a validation error"
     )
     .orFalse
 
@@ -81,7 +90,8 @@ object OpenAPIJsonSchemaOpts {
       CommonOpts.sources,
       CommonOpts.outputDirectory,
       verboseNames,
-      failOnValidationErrors,
+      failOnInputValidationErrors,
+      failOnOutputValidationErrors,
       useEnumTraitSyntax,
       outputJson,
       debug,

--- a/modules/cli/src/runners/OpenApi.scala
+++ b/modules/cli/src/runners/OpenApi.scala
@@ -30,7 +30,8 @@ object OpenApi {
       ParseAndCompile.openapi(
         opts.inputFiles,
         useVerboseNames = opts.useVerboseNames,
-        failOnValidationErrors = opts.failOnValidationErrors,
+        failOnInputValidationErrors = opts.failOnInputValidationErrors,
+        failOnOutputValidationErrors = opts.failOnOutputValidationErrors,
         transformers,
         opts.useEnumTraitSyntax,
         opts.debug
@@ -47,7 +48,8 @@ object OpenApi {
       ParseAndCompile.jsonSchema(
         opts.inputFiles,
         useVerboseNames = opts.useVerboseNames,
-        failOnValidationErrors = opts.failOnValidationErrors,
+        failOnInputValidationErrors = opts.failOnInputValidationErrors,
+        failOnOutputValidationErrors = opts.failOnOutputValidationErrors,
         transformers,
         opts.useEnumTraitSyntax,
         opts.debug

--- a/modules/cli/src/runners/openapi/ParseAndCompile.scala
+++ b/modules/cli/src/runners/openapi/ParseAndCompile.scala
@@ -26,7 +26,8 @@ object ParseAndCompile {
   def openapi(
       inputPaths: NonEmptyList[os.Path],
       useVerboseNames: Boolean,
-      failOnValidationErrors: Boolean,
+      failOnInputValidationErrors: Boolean,
+      failOnOutputValidationErrors: Boolean,
       transformers: List[TranslateTransformer],
       useEnumTraitSyntax: Boolean,
       debug: Boolean
@@ -35,7 +36,8 @@ object ParseAndCompile {
     val inputs = readAll(inputPaths, includedExtensions)
     val opts = OpenApiCompiler.Options(
       useVerboseNames,
-      failOnValidationErrors,
+      failOnInputValidationErrors,
+      failOnOutputValidationErrors,
       transformers,
       useEnumTraitSyntax,
       debug
@@ -46,7 +48,8 @@ object ParseAndCompile {
   def jsonSchema(
       inputPaths: NonEmptyList[os.Path],
       useVerboseNames: Boolean,
-      failOnValidationErrors: Boolean,
+      failOnInputValidationErrors: Boolean,
+      failOnOutputValidationErrors: Boolean,
       transformers: List[TranslateTransformer],
       useEnumTraitSyntax: Boolean,
       debug: Boolean
@@ -55,7 +58,8 @@ object ParseAndCompile {
     val inputs = readAll(inputPaths, includedExtensions)
     val opts = OpenApiCompiler.Options(
       useVerboseNames,
-      failOnValidationErrors,
+      failOnInputValidationErrors,
+      failOnOutputValidationErrors,
       transformers,
       useEnumTraitSyntax,
       debug

--- a/modules/json-schema/tests/src/TestUtils.scala
+++ b/modules/json-schema/tests/src/TestUtils.scala
@@ -52,7 +52,8 @@ object TestUtils {
       JsonSchemaCompiler.parseAndCompile(
         OpenApiCompiler.Options(
           useVerboseNames = false,
-          failOnValidationErrors = false,
+          failOnInputValidationErrors = false,
+          failOnOutputValidationErrors = false,
           List.empty,
           input0.smithyVersion == SmithyVersion.One,
           debug = true

--- a/modules/openapi/src/ModelError.scala
+++ b/modules/openapi/src/ModelError.scala
@@ -18,6 +18,7 @@ package smithytranslate.openapi
 import scala.util.control.NoStackTrace
 import cats.data.NonEmptyChain
 import cats.syntax.all._
+import software.amazon.smithy.model.validation.ValidationEvent
 
 sealed trait ModelError extends Throwable
 
@@ -34,16 +35,11 @@ object ModelError {
   }
 
   case class SmithyValidationFailed(
-      smithyValidationError: Throwable,
-      otherErrors: List[ModelError]
+      smithyValidationEvents: List[ValidationEvent]
   ) extends ModelError {
     override def getMessage(): String = {
-      val otherMessages = otherErrors.map(_.getMessage).mkString("\n")
-      "Failed to validate the Smithy model. Previous error message follows:\n" +
-        otherMessages
+      s"Failed to validate the Smithy model:\n${smithyValidationEvents.mkString("\n")}"
     }
-    override def getCause(): Throwable = smithyValidationError
-
   }
 
   case class BadRef(ref: String) extends ModelError

--- a/modules/openapi/src/OpenApiCompiler.scala
+++ b/modules/openapi/src/OpenApiCompiler.scala
@@ -15,6 +15,7 @@
 
 package smithytranslate.openapi
 
+import scala.jdk.OptionConverters._
 import io.swagger.v3.oas.models.OpenAPI
 import software.amazon.smithy.model.{Model => SmithyModel}
 import cats.syntax.all._
@@ -33,6 +34,7 @@ import smithytranslate.openapi.OpenApiCompiler.SmithyVersion.Two
 import software.amazon.smithy.model.validation.ValidatedResultException
 import software.amazon.smithy.model.validation.Severity
 import java.util.stream.Collectors
+import software.amazon.smithy.model.validation.ValidatedResult
 
 /** Converts openapi to a smithy model.
   */
@@ -81,7 +83,8 @@ object OpenApiCompiler {
 
   final case class Options(
       useVerboseNames: Boolean,
-      failOnValidationErrors: Boolean,
+      failOnInputValidationErrors: Boolean,
+      failOnOutputValidationErrors: Boolean,
       transformers: List[ProjectionTransformer],
       useEnumTraitSyntax: Boolean,
       debug: Boolean
@@ -126,7 +129,9 @@ object OpenApiCompiler {
             val result = parser.readContents(in, null, null)
 
             if (
-              opts.failOnValidationErrors && !result.getMessages().isEmpty()
+              opts.failOnInputValidationErrors && !result
+                .getMessages()
+                .isEmpty()
             ) {
               Left(result.getMessages().asScala.toList)
             } else {
@@ -151,21 +156,55 @@ object OpenApiCompiler {
       .foldMap { case (c, e) => OpenApiToIModel.compile(c, e) }
       .map(IModelPostProcessor(opts.useVerboseNames))
       .map(new IModelToSmithy(opts.useEnumTraitSyntax))
-    val errors = errors0.toList
+    val translationErrors = errors0.toList
 
-    scala.util
-      .Try(validate(smithy0))
-      .toEither
-      .leftMap(opts.debugModelValidationError)
-      .map(transform(opts))
-      .fold(
-        err => Failure(err, errors),
-        model => Success(errors.toList, model)
-      )
+    val assembled: ValidatedResult[SmithyModel] = validate(smithy0)
+    val validationEvents = if (opts.debug) {
+      assembled.getValidationEvents()
+    } else {
+      val errorEvents = assembled.getValidationEvents(Severity.ERROR)
+      val dangerEvents = assembled.getValidationEvents(Severity.DANGER)
+      val criticalErrors = new java.util.ArrayList(errorEvents)
+      criticalErrors.addAll(dangerEvents)
+      criticalErrors
+    }
+    val problematicSeverities = Set(Severity.DANGER, Severity.ERROR)
+    val hasProblematicEvents = validationEvents
+      .iterator()
+      .asScala
+      .map(_.getSeverity())
+      .exists(problematicSeverities)
+
+    val allErrors =
+      if (hasProblematicEvents) {
+        val smithyValidationFailed =
+          ModelError.SmithyValidationFailed(validationEvents.asScala.toList)
+        smithyValidationFailed :: translationErrors
+      } else {
+        translationErrors
+      }
+
+    val transformedModel =
+      assembled.getResult().toScala.map(transform(opts))
+
+    (transformedModel, NonEmptyList.fromList(allErrors)) match {
+      case (None, Some(nonEmptyErrors)) =>
+        Failure(nonEmptyErrors.head, nonEmptyErrors.tail)
+      case (None, None) =>
+        Failure(ModelError.SmithyValidationFailed(Nil), translationErrors)
+      case (Some(model), None) =>
+        Success(translationErrors, model)
+      case (Some(model), Some(nonEmptyErrors)) =>
+        if (opts.failOnOutputValidationErrors) {
+          Failure(nonEmptyErrors.head, nonEmptyErrors.tail)
+        } else {
+          Success(allErrors, model)
+        }
+    }
   }
 
-  private def validate(model: SmithyModel): SmithyModel =
-    SmithyModel.assembler().discoverModels().addModel(model).assemble().unwrap()
+  private def validate(model: SmithyModel): ValidatedResult[SmithyModel] =
+    SmithyModel.assembler().discoverModels().addModel(model).assemble()
 
   private def transform(opts: Options)(model: SmithyModel): SmithyModel =
     opts.transformers.foldLeft(model)((m, t) =>

--- a/modules/openapi/tests/src/DebugSpec.scala
+++ b/modules/openapi/tests/src/DebugSpec.scala
@@ -32,7 +32,8 @@ final class DebugSpec extends munit.FunSuite {
     OpenApiCompiler.parseAndCompile(
       OpenApiCompiler.Options(
         useVerboseNames = false,
-        failOnValidationErrors = false,
+        failOnOpenapiValidationErrors = false,
+        failOnSmithyValidationErrors = true,
         List.empty,
         useEnumTraitSyntax = false,
         debug
@@ -45,8 +46,8 @@ final class DebugSpec extends munit.FunSuite {
       loc: Location
   ) = {
     load("issue-23.json", debug) match {
-      case Failure(ex: ValidatedResultException, _) =>
-        assertEquals(ex.getValidationEvents().size(), expectedCount)
+      case Failure(ModelError.SmithyValidationFailed(events), _) =>
+        assertEquals(events.size, expectedCount)
       case Failure(cause, _) =>
         fail(
           s"expected a ValidatedResultException but got a ${cause.getClass().getSimpleName()}"
@@ -55,10 +56,10 @@ final class DebugSpec extends munit.FunSuite {
     }
   }
 
-  test("load with debug leaves validation events untouched") {
+  test("load with debug leaves validation events untouched".only) {
     testFilteredErrors(debug = true, expectedCount = 5)
   }
-  test("load without debug filters validation events") {
+  test("load without debug filters validation events".only) {
     testFilteredErrors(debug = false, expectedCount = 2)
   }
 }

--- a/modules/openapi/tests/src/TestUtils.scala
+++ b/modules/openapi/tests/src/TestUtils.scala
@@ -97,7 +97,8 @@ object TestUtils {
       OpenApiCompiler.parseAndCompile(
         OpenApiCompiler.Options(
           useVerboseNames = false,
-          failOnValidationErrors = false,
+          failOnOpenapiValidationErrors = false,
+          failOnSmithyValidationErrors = true,
           List.empty,
           input0.smithyVersion == SmithyVersion.One,
           debug = true


### PR DESCRIPTION
This makes the tool a little bit more lenient for some users. A flag is added to re-enable validation.