### PR TITLE
revert org change

### DIFF
--- a/buildDeps.sc
+++ b/buildDeps.sc
@@ -3,8 +3,8 @@ import mill.define._
 import mill.scalalib._
 
 object alloy {
-  val alloyVersion = "0.3.25"
-  val org = "io.github.disneystreaming.alloy"
+  val alloyVersion = "0.3.26"
+  val org = "com.disneystreaming.alloy"
   val core = ivy"$org:alloy-core:$alloyVersion"
   val protobuf = ivy"$org:alloy-protobuf:$alloyVersion"
 }

--- a/buildSetup.sc
+++ b/buildSetup.sc
@@ -67,7 +67,7 @@ trait BasePublishModule extends BaseModule with SonatypeCentralPublishModule {
 
   def pomSettings = PomSettings(
     description = "A smithy-translation toolkit",
-    organization = "io.github.disneystreaming.smithy",
+    organization = "com.disneystreaming.smithy",
     url = "https://github.com/disneystreaming/smithy-translate",
     licenses = Seq(
       License(

--- a/modules/cli/src/SmithyBuildJsonWriter.scala
+++ b/modules/cli/src/SmithyBuildJsonWriter.scala
@@ -23,10 +23,10 @@ object SmithyBuildJsonWriter {
       "maven" -> ujson.Obj(
         "dependencies" -> ujson.Arr(
           ujson.Str(
-            s"io.github.disneystreaming.alloy:alloy-core:${BuildInfo.alloyVersion}"
+            s"com.disneystreaming.alloy:alloy-core:${BuildInfo.alloyVersion}"
           ),
           ujson.Str(
-            s"io.github.disneystreaming.smithy:smithytranslate-traits:${BuildInfo.cliVersion}"
+            s"com.disneystreaming.smithy:smithytranslate-traits:${BuildInfo.cliVersion}"
           )
         )
       )

--- a/modules/proto-examples/README.md
+++ b/modules/proto-examples/README.md
@@ -10,6 +10,6 @@ mill cli.run smithy-to-proto -i modules/proto-examples/smithy/ modules/proto-exa
 
 ```
 $ grpcurl -plaintext localhost:9000 list
-$ grpcurl -plaintext localhost:9000 describe io.github.disneystreaming.smithyproto.demo.Hello
-$ grpcurl -plaintext -d '{"name":"john"}' localhost:9000 io.github.disneystreaming.smithyproto.demo.Hello/SayHello
+$ grpcurl -plaintext localhost:9000 describe com.disneystreaming.smithyproto.demo.Hello
+$ grpcurl -plaintext -d '{"name":"john"}' localhost:9000 com.disneystreaming.smithyproto.demo.Hello/SayHello
 ```

--- a/smithy-build.json
+++ b/smithy-build.json
@@ -1,9 +1,11 @@
 {
   "version": "1.0",
-  "imports": ["./modules/proto-examples/smithy"],
+  "imports": [
+    "./modules/proto-examples/smithy"
+  ],
   "maven": {
     "dependencies": [
-      "io.github.disneystreaming.alloy:alloy-core:0.3.22"
+      "com.disneystreaming.alloy:alloy-core:0.3.26"
     ]
   },
   "languageServer": "software.amazon.smithy:smithy-language-server:0.7.0"


### PR DESCRIPTION
Now that we have the `com.disneystreaming` org available in Sonatype, this reverts to use it once again.