### PR TITLE
Update Alloy version to 0.3.28 and fix Protobuf timestamp implementations

### DIFF
--- a/buildDeps.sc
+++ b/buildDeps.sc
@@ -3,7 +3,7 @@ import mill.define._
 import mill.scalalib._
 
 object alloy {
-  val alloyVersion = "0.3.26"
+  val alloyVersion = "0.3.28"
   val org = "com.disneystreaming.alloy"
   val core = ivy"$org:alloy-core:$alloyVersion"
   val protobuf = ivy"$org:alloy-protobuf:$alloyVersion"

--- a/buildSetup.sc
+++ b/buildSetup.sc
@@ -47,7 +47,7 @@ trait BaseModule extends Module with HeaderModule {
        |
        |Unless required by applicable law or agreed to in writing, software
        |distributed under the License is distributed on an "AS IS" BASIS,
-       |WITHOUT WARRANTIES OR CONDITIONS OF ANY , either express or implied.
+       |WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
        |See the License for the specific language governing permissions and
        |limitations under the License.
        |""".stripMargin

--- a/buildSetup.sc
+++ b/buildSetup.sc
@@ -21,9 +21,9 @@ import mill.scalalib.api.ZincWorkerUtil
 import scala.Ordering.Implicits._
 
 object ScalaVersions {
-  val scala212 = "2.12.18"
-  val scala213 = "2.13.12"
-  val scala3 = "3.3.1"
+  val scala212 = "2.12.20"
+  val scala213 = "2.13.16"
+  val scala3 = "3.3.6"
 
   val scalaVersions = List(scala213, scala212, scala3)
 }
@@ -47,7 +47,7 @@ trait BaseModule extends Module with HeaderModule {
        |
        |Unless required by applicable law or agreed to in writing, software
        |distributed under the License is distributed on an "AS IS" BASIS,
-       |WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       |WITHOUT WARRANTIES OR CONDITIONS OF ANY , either express or implied.
        |See the License for the specific language governing permissions and
        |limitations under the License.
        |""".stripMargin
@@ -123,7 +123,7 @@ trait BaseScalaModule extends ScalaModule with BaseModule with ScalafmtModule {
   override def scalacPluginIvyDeps = T {
     val sv = scalaVersion()
     val plugins =
-      if (sv.startsWith("2.")) Agg(ivy"org.typelevel:::kind-projector:0.13.2")
+      if (sv.startsWith("2.")) Agg(ivy"org.typelevel:::kind-projector:0.13.3")
       else Agg.empty
     super.scalacPluginIvyDeps() ++ plugins
   }
@@ -134,7 +134,7 @@ trait BaseScalaModule extends ScalaModule with BaseModule with ScalafmtModule {
 }
 
 trait BaseScalaJSModule extends BaseScalaModule with ScalaJSModule {
-  def scalaJSVersion = "1.11.0"
+  def scalaJSVersion = "1.19.0"
   def moduleKind = ModuleKind.CommonJSModule
 }
 

--- a/modules/cli/src/opts/FormatterOpts.scala
+++ b/modules/cli/src/opts/FormatterOpts.scala
@@ -63,6 +63,6 @@ object FormatterOpts {
     Command(name = "format", header = header)(formatOpts)
 
   val format: Opts[Format] =
-    Opts.subcommand(command = formatCommand).map(Format)
+    Opts.subcommand(command = formatCommand).map(Format.apply)
 
 }

--- a/modules/cli/src/opts/OpenAPIJsonSchemaOpts.scala
+++ b/modules/cli/src/opts/OpenAPIJsonSchemaOpts.scala
@@ -103,7 +103,7 @@ object OpenAPIJsonSchemaOpts {
     header = "Take Open API specs as input and produce Smithy files as output."
   ) { getOpts(isOpenapi = true) }
   val openApiToSmithy =
-    Opts.subcommand(openApiToSmithyCmd).map(OpenApiTranslate)
+    Opts.subcommand(openApiToSmithyCmd).map(OpenApiTranslate.apply)
 
   private val jsonSchemaToSmithyCmd = Command(
     name = "json-schema-to-smithy",
@@ -111,5 +111,5 @@ object OpenAPIJsonSchemaOpts {
       "Take Json Schema specs as input and produce Smithy files as output."
   ) { getOpts(isOpenapi = false) }
   val jsonSchemaToSmithy =
-    Opts.subcommand(jsonSchemaToSmithyCmd).map(OpenApiTranslate)
+    Opts.subcommand(jsonSchemaToSmithyCmd).map(OpenApiTranslate.apply)
 }

--- a/modules/cli/src/opts/ProtoOpts.scala
+++ b/modules/cli/src/opts/ProtoOpts.scala
@@ -53,5 +53,6 @@ object ProtoOpts {
     header =
       "Take Smithy definitions as input and produce Proto files as output."
   ) { opts }
-  val smithyToProto = Opts.subcommand(smithyToProtoCmd).map(ProtoTranslate.apply)
+  val smithyToProto =
+    Opts.subcommand(smithyToProtoCmd).map(ProtoTranslate.apply)
 }

--- a/modules/cli/src/opts/ProtoOpts.scala
+++ b/modules/cli/src/opts/ProtoOpts.scala
@@ -53,5 +53,5 @@ object ProtoOpts {
     header =
       "Take Smithy definitions as input and produce Proto files as output."
   ) { opts }
-  val smithyToProto = Opts.subcommand(smithyToProtoCmd).map(ProtoTranslate)
+  val smithyToProto = Opts.subcommand(smithyToProtoCmd).map(ProtoTranslate.apply)
 }

--- a/modules/proto/src/smithytranslate/proto3/internals/Compiler.scala
+++ b/modules/proto/src/smithytranslate/proto3/internals/Compiler.scala
@@ -780,9 +780,9 @@ object Compiler {
 
   private[proto3] def hasProtoCompact(m: Shape): Boolean =
     compactTraits.exists(m.hasTrait) ||
-    m
-      .getTrait(classOf[alloy.proto.ProtoOffsetDateTimeFormatTrait])
-      .toScala
-      .map(_.getValue())
-      .contains(alloy.proto.ProtoOffsetDateTimeFormatTrait.PROTOBUF)
+      m
+        .getTrait(classOf[alloy.proto.ProtoOffsetDateTimeFormatTrait])
+        .toScala
+        .map(_.getValue())
+        .contains(alloy.proto.ProtoOffsetDateTimeFormatTrait.PROTOBUF)
 }

--- a/modules/proto/src/smithytranslate/proto3/internals/Compiler.scala
+++ b/modules/proto/src/smithytranslate/proto3/internals/Compiler.scala
@@ -36,6 +36,7 @@ import alloy.proto.ProtoTimestampFormatTrait.TimestampFormat
 import smithytranslate.proto3.internals.ProtoIR.Type.AlloyTypes
 
 private[proto3] class Compiler(model: Model, allShapes: Boolean) {
+  import Compiler.*
 
   // Reference:
   // 1. https://github.com/protocolbuffers/protobuf/blob/master/docs/field_presence.md
@@ -168,17 +169,6 @@ private[proto3] class Compiler(model: Model, allShapes: Boolean) {
 
   private def hasProtoWrapped(m: Shape): Boolean =
     m.hasTrait(classOf[alloy.proto.ProtoWrappedTrait])
-
-  private val compactTraits = Set(
-    alloy.proto.ProtoCompactUUIDTrait.ID,
-    alloy.proto.ProtoCompactLocalDateTrait.ID,
-    alloy.proto.ProtoCompactYearMonthTrait.ID,
-    alloy.proto.ProtoCompactMonthDayTrait.ID,
-    alloy.proto.ProtoCompactOffsetDateTimeTrait.ID
-  )
-
-  private def hasProtoCompact(m: Shape): Boolean =
-    compactTraits.exists(m.hasTrait)
 
   private def isProtoService(ss: ServiceShape): Boolean =
     ss.hasTrait(classOf[ProtoEnabledTrait])
@@ -721,6 +711,9 @@ private[proto3] class Compiler(model: Model, allShapes: Boolean) {
             case TimestampFormat.EPOCH_MILLIS =>
               if (isWrapped) Some(Type.AlloyWrappers.EpochMillisTimestamp)
               else Some(Type.AlloyTypes.EpochMillisTimestamp)
+            case TimestampFormat.RFC3339_STRING =>
+              if (isWrapped) Some(Type.GoogleWrappers.String)
+              else Some(Type.String)
           }
         }
 
@@ -775,4 +768,21 @@ private[proto3] class Compiler(model: Model, allShapes: Boolean) {
       }
     }
   }
+}
+
+object Compiler {
+  private val compactTraits = Set(
+    alloy.proto.ProtoCompactUUIDTrait.ID,
+    alloy.proto.ProtoCompactLocalDateTrait.ID,
+    alloy.proto.ProtoCompactYearMonthTrait.ID,
+    alloy.proto.ProtoCompactMonthDayTrait.ID
+  )
+
+  private[proto3] def hasProtoCompact(m: Shape): Boolean =
+    compactTraits.exists(m.hasTrait) ||
+    m
+      .getTrait(classOf[alloy.proto.ProtoOffsetDateTimeFormatTrait])
+      .toScala
+      .map(_.getValue())
+      .contains(alloy.proto.ProtoOffsetDateTimeFormatTrait.PROTOBUF)
 }

--- a/modules/proto/test/src/smithytranslate/proto3/internals/CompilerRendererSuite.scala
+++ b/modules/proto/test/src/smithytranslate/proto3/internals/CompilerRendererSuite.scala
@@ -1599,7 +1599,7 @@ class CompilerRendererSuite extends FunSuite {
                     |use alloy.proto#protoEnabled
                     |use alloy#OffsetDateTime
                     |use alloy.proto#protoWrapped
-                    |use alloy.proto#protoCompactOffsetDateTime
+                    |use alloy.proto#protoOffsetDateTimeFormat
                     |
                     |@protoEnabled
                     |structure MyStructure {
@@ -1608,11 +1608,11 @@ class CompilerRendererSuite extends FunSuite {
                     |  @protoWrapped
                     |  wrapped: OffsetDateTime
 
-                    |  @protoCompactOffsetDateTime
+                    |  @protoOffsetDateTimeFormat("PROTOBUF")
                     |  compact: OffsetDateTime
 
                     |  @protoWrapped
-                    |  @protoCompactOffsetDateTime
+                    |  @protoOffsetDateTimeFormat("PROTOBUF")
                     |  wrappedCompact: OffsetDateTime
                     |}
                     |""".stripMargin


### PR DESCRIPTION
## Goal

Update Alloy version to 0.3.28.

## Description

I updated Alloy to version 0.3.28, which came with some Prototbuf timestamp trait changes.  In particular, `alloy.proto#protoCompactOffsetDateTime` has been removed in favor of `alloy.proto#protoOffsetDateTimeFormat("PROTOBUF")`.

I updated the implementation in `Compiler` in two ways:
1. `TimestampFormat.RFC3339_STRING` needed a case in the `typeVisitor#timestampShape` function, which I set to use `String` values since it's being represented as a String date
2. `hasProtoCompact` now references the value in `protoOffsetDateTimeFormat` instead of checking for the `protoCompactOffsetDateTime` trait.  I was also having issues trying to narrow down a bug with the `hasProtoCompact` function so I moved it into the companion object to also make it more test-able

## Side Quest

I also updated Scala versions because my LSP was getting cranky about using the older versions.  Along with the Scala upgrades came the Kind Projector and Scala JS updates.  The compiler was also unhappy that some case classes were being initialized without explicitly using the `apply` methods.