### PR TITLE
Fix allof with single ref

### DIFF
--- a/modules/compiler-core/src/internals/postprocess/AllOfTransformer.scala
+++ b/modules/compiler-core/src/internals/postprocess/AllOfTransformer.scala
@@ -134,9 +134,9 @@ private[compiler] object AllOfTransformer extends IModelPostProcessor {
     val newFields =
       parent.localFields.map(f => f.copy(id = f.id.copy(modelId = newDef.id)))
 
-    val newHints = parent.hints 
+    val newHints = parent.hints
     val remove = parent
-    val nd = newDef.copy(localFields = newDef.localFields ++ newFields, hints = newHints)
+    val nd = newDef.copy(localFields = newDef.localFields ++ newFields, hints = newDef.hints ++ newHints)
     NonTopLevelParentNoRefsResult(nd, remove)
   }
 

--- a/modules/compiler-core/src/internals/postprocess/AllOfTransformer.scala
+++ b/modules/compiler-core/src/internals/postprocess/AllOfTransformer.scala
@@ -133,8 +133,10 @@ private[compiler] object AllOfTransformer extends IModelPostProcessor {
     // shape (meaning it is a fabricated AllOf shape created by the OpenApi => IModel transform)
     val newFields =
       parent.localFields.map(f => f.copy(id = f.id.copy(modelId = newDef.id)))
+
+    val newHints = parent.hints 
     val remove = parent
-    val nd = newDef.copy(localFields = newDef.localFields ++ newFields)
+    val nd = newDef.copy(localFields = newDef.localFields ++ newFields, hints = newHints)
     NonTopLevelParentNoRefsResult(nd, remove)
   }
 
@@ -164,7 +166,6 @@ private[compiler] object AllOfTransformer extends IModelPostProcessor {
               val parentHasOtherReferences =
                 isReferencedAsTarget(parent, all)
               val parentIsTopLevel = parent.hints.contains(Hint.TopLevel)
-
               if (parentHasOtherReferences) {
                 val result = parentHasOtherReferencesCase(parent, newDef)
                 newDef = result.newDef

--- a/modules/json-schema/test/src/AllOfSpec.scala
+++ b/modules/json-schema/test/src/AllOfSpec.scala
@@ -143,5 +143,54 @@ final class AllOfSpec extends munit.FunSuite {
 
     TestUtils.runConversionTest(jsonSchString, expectedString)
   }
+  
+  test("unions - single allOf reference") {
+    val jsonSchString =
+      """|{
+         |  "$id": "test.json",
+         |  "$schema": "http://json-schema.org/draft-07/schema#",
+         |  "title": "Test",
+         |  "type" : "object",
+         |  "properties" : {
+         |    "example": {
+         |      "type": "object",
+         |      "allOf": [
+         |        { "$ref": "#/$defs/two" }
+         |      ]
+         |    }
+         |  },
+         |  "$defs": {
+         |    "two": {
+         |      "type" : "object",
+         |      "properties" : {
+         |         "vehicle" : {
+         |            "type" : "string"
+         |         },
+         |         "price" : {
+         |            "type" : "integer"
+         |         }
+         |      }
+         |    }
+         |  }
+         |}
+         |""".stripMargin
+
+    val expectedString = """|namespace foo
+                            |structure Example with [Two] {}
+                            |
+                            |structure Test {
+                            |  example: Example
+                            |}
+                            |
+                            |@mixin
+                            |structure Two {
+                            |  vehicle: String,
+                            |  price: Integer
+                            |}
+                            |
+                            |""".stripMargin
+
+    TestUtils.runConversionTest(jsonSchString, expectedString)
+  }
 
 }

--- a/modules/openapi/test/src/AllOfSpec.scala
+++ b/modules/openapi/test/src/AllOfSpec.scala
@@ -16,6 +16,42 @@
 package smithytranslate.compiler.openapi
 
 final class AllOfSpec extends munit.FunSuite {
+  
+  test("allOf - one ref") {
+    val openapiString = """|openapi: '3.0.'
+                           |info:
+                           |  title: test
+                           |  version: '1.0'
+                           |paths: {}
+                           |components:
+                           |  schemas:
+                           |    Other:
+                           |      description: other
+                           |      type: object
+                           |      properties:
+                           |        l:
+                           |          type: integer
+                           |    Object:
+                           |      description: object
+                           |      allOf:
+                           |        - $ref: "#/components/schemas/Other"
+                           |""".stripMargin
+
+    val expectedString = """|namespace foo
+                            |
+                            |/// object
+                            |structure Object with [Other] {
+                            |}
+                            |
+                            |/// other
+                            |@mixin
+                            |structure Other {
+                            |    l: Integer
+                            |}
+                            |""".stripMargin
+
+    TestUtils.runConversionTest(openapiString, expectedString)
+  }
 
   test("allOf - one ref one embedded") {
     val openapiString = """|openapi: '3.0.'


### PR DESCRIPTION
An `allOf` with a single reference would fail to generate both the mixin and reference to that mixin.

Another way to do this may be to just inline the reference, but I think this makes more sense, given that `allOf` with a single ref signals some intent to eventually extend the schema, and keeping it this way improves smithy source compatibility