### PR TITLE
Add support for writing documentation traits to protobuf output

### DIFF
--- a/modules/proto/src/smithytranslate/proto3/internals/ProtoIR.scala
+++ b/modules/proto/src/smithytranslate/proto3/internals/ProtoIR.scala
@@ -45,7 +45,8 @@ private[internals] object ProtoIR {
   final case class Message(
       name: String,
       elements: List[MessageElement],
-      reserved: List[Reserved]
+      reserved: List[Reserved],
+      doc: Option[String] = None
   )
 
   sealed trait MessageElement
@@ -55,13 +56,14 @@ private[internals] object ProtoIR {
     final case class OneofElement(oneof: Oneof) extends MessageElement
   }
 
-  final case class Oneof(name: String, fields: List[Field])
+  final case class Oneof(name: String, fields: List[Field], doc: Option[String] = None)
 
   final case class Field(
       deprecated: Boolean,
       ty: Type,
       name: String,
-      number: Int
+      number: Int,
+      doc: Option[String] = None
   )
 
   sealed trait Reserved
@@ -71,14 +73,15 @@ private[internals] object ProtoIR {
     final case class Range(start: Int, end: Int) extends Reserved
   }
 
-  case class EnumValue(name: String, intValue: Int)
+  case class EnumValue(name: String, intValue: Int, doc: Option[String] = None)
   case class Enum(
       name: String,
       values: List[EnumValue],
-      reserved: List[Reserved]
+      reserved: List[Reserved],
+      doc: Option[String] = None
   )
 
-  final case class Service(name: String, rpcs: List[Rpc])
+  final case class Service(name: String, rpcs: List[Rpc], doc: Option[String] = None)
 
   final case class RpcMessage(fqn: Fqn, importFqn: Fqn)
 
@@ -87,7 +90,8 @@ private[internals] object ProtoIR {
       streamingRequest: Boolean,
       request: RpcMessage,
       streamingResponse: Boolean,
-      response: RpcMessage
+      response: RpcMessage,
+      doc: Option[String] = None
   )
 
   sealed trait Type {

--- a/modules/proto/test/src/smithytranslate/proto3/internals/CompilerSuite.scala
+++ b/modules/proto/test/src/smithytranslate/proto3/internals/CompilerSuite.scala
@@ -36,11 +36,13 @@ class CompilerSuite extends FunSuite {
             deprecated = false,
             Type.String,
             "value",
-            1
+            1,
+            None
           )
         )
       ),
-      Nil
+      Nil,
+      None
     )
   )
 

--- a/modules/proto/test/src/smithytranslate/proto3/internals/RendererSuite.scala
+++ b/modules/proto/test/src/smithytranslate/proto3/internals/RendererSuite.scala
@@ -35,7 +35,8 @@ class RendererSuite extends FunSuite {
                     deprecated = false,
                     Type.Int32,
                     "a",
-                    1
+                    1,
+                    Some("field a doc")
                   )
                 ),
                 MessageElement.FieldElement(
@@ -43,11 +44,13 @@ class RendererSuite extends FunSuite {
                     deprecated = false,
                     Type.ListType(Type.String),
                     "b",
-                    2
+                    2,
+                    Some("field b doc")
                   )
                 )
               ),
-              Nil
+              Nil,
+              Some("message doc")
             )
           )
         )
@@ -61,8 +64,11 @@ class RendererSuite extends FunSuite {
           |
           |package com.example;
           |
+          |// message doc
           |message Foo {
+          |  // field a doc
           |  int32 a = 1;
+          |  // field b doc
           |  repeated string b = 2;
           |}
           |""".stripMargin
@@ -75,10 +81,10 @@ class RendererSuite extends FunSuite {
       "Foo",
       List(
         MessageElement.FieldElement(
-          Field(deprecated = false, Type.Int32, "a", 1)
+          Field(deprecated = false, Type.Int32, "a", 1, None)
         ),
         MessageElement.FieldElement(
-          Field(deprecated = false, Type.ListType(Type.String), "b", 2)
+          Field(deprecated = false, Type.ListType(Type.String), "b", 2, None)
         )
       ),
       List(
@@ -86,7 +92,8 @@ class RendererSuite extends FunSuite {
         Reserved.Range(5, 8),
         Reserved.Name("c"),
         Reserved.Name("d")
-      )
+      ),
+      None
     )
 
     val result = Text.renderText(Renderer.renderMessage(node))
@@ -105,14 +112,15 @@ class RendererSuite extends FunSuite {
     val node = Enum(
       "SomeEnum",
       List(
-        EnumValue("V1", 1)
+        EnumValue("V1", 1, None)
       ),
       List(
         Reserved.Number(3),
         Reserved.Range(5, 8),
         Reserved.Name("c"),
         Reserved.Name("d")
-      )
+      ),
+      None
     )
 
     val result = Text.renderText(Renderer.renderEnum(node))
@@ -143,19 +151,23 @@ class RendererSuite extends FunSuite {
                         deprecated = false,
                         Type.Int32,
                         "a",
-                        1
+                        1,
+                        None
                       ),
                       Field(
                         deprecated = true,
                         Type.ListType(Type.String),
                         "b",
-                        2
+                        2,
+                        None
                       )
-                    )
+                    ),
+                    None
                   )
                 )
               ),
-              Nil
+              Nil,
+              None
             )
           )
         )
@@ -189,13 +201,14 @@ class RendererSuite extends FunSuite {
             Enum(
               "TopLevelEnum",
               List(
-                EnumValue("FALSE", 0),
-                EnumValue("TRUE", 1)
+                EnumValue("FALSE", 0, None),
+                EnumValue("TRUE", 1, None)
               ),
               List(
                 Reserved.Name("c"),
                 Reserved.Name("d")
-              )
+              ),
+              None
             )
           )
         ),
@@ -208,18 +221,20 @@ class RendererSuite extends FunSuite {
                   Enum(
                     "Corpus",
                     List(
-                      EnumValue("UNIVERSAL", 0),
-                      EnumValue("WEB", 1),
-                      EnumValue("VIDEO", 2)
+                      EnumValue("UNIVERSAL", 0, Some("Not the studio")),
+                      EnumValue("WEB", 1, None),
+                      EnumValue("VIDEO", 2, None)
                     ),
                     List(
                       Reserved.Number(3),
                       Reserved.Range(5, 8)
-                    )
+                    ),
+                    None
                   )
                 )
               ),
-              Nil
+              Nil,
+              None
             )
           )
         )
@@ -242,6 +257,7 @@ class RendererSuite extends FunSuite {
           |message Foo {
           |  enum Corpus {
           |    reserved 3, 5 to 8;
+          |    // Not the studio
           |    UNIVERSAL = 0;
           |    WEB = 1;
           |    VIDEO = 2;


### PR DESCRIPTION
This change will propagate the `@documentation` trait into the generated grpc/proto files as comments. 

This is useful for generating `.proto` files where there are linter requirements for having comments on some elements within the file. It also allows comments to be propagated for protobuf-aware IDEs to surface to the user.

If there are backward-compatibility concerns, let me know if there is a preferred way to make this opt-in, e.g. a new trait, CLI option, etc