### PR TITLE
JsonSchema: Fix integer ranges and make integer/long support a little more robust

### DIFF
--- a/modules/json-schema/src/internals/Extractors.scala
+++ b/modules/json-schema/src/internals/Extractors.scala
@@ -96,7 +96,7 @@ private[json_schema] object Extractors {
               case DoubleRange(min, max) =>
                 (PDouble, min.map(BigDecimal(_)), max.map(BigDecimal(_)))
 
-              case _ if s.requiresInteger() => (PInt, None, None) 
+              case _ if s.requiresInteger()  => (PInt, None, None)
               case _ if !s.requiresInteger() => (PDouble, None, None)
             }
 
@@ -456,7 +456,7 @@ private[json_schema] object Extractors {
 
   object IntRange {
     def unapply(sch: Schema): Option[(Option[Int], Option[Int])] = sch match {
-      case s: NumberSchema if s.isRequiresNumber() =>
+      case s: NumberSchema if s.requiresInteger() =>
         val min = Option(s.getMinimum())
         val max = Option(s.getMaximum())
         (min, max) match {
@@ -473,7 +473,7 @@ private[json_schema] object Extractors {
   object DoubleRange {
     def unapply(sch: Schema): Option[(Option[Double], Option[Double])] =
       sch match {
-        case s: NumberSchema if !s.isRequiresNumber() =>
+        case s: NumberSchema if !s.requiresInteger() =>
           val min = Option(s.getMinimum())
           val max = Option(s.getMaximum())
           Some((min.map(_.doubleValue()), max.map(_.doubleValue())))

--- a/modules/json-schema/src/internals/Extractors.scala
+++ b/modules/json-schema/src/internals/Extractors.scala
@@ -84,31 +84,29 @@ private[json_schema] object Extractors {
         // N:
         //   type: number
         case (s: NumberSchema) =>
-          val prim =
-            if (s.requiresInteger()) Some(PInt)
-            else Some(PDouble)
 
-          val (typedMin, typedMax): (Double, Double) = prim match {
-            case Some(PInt) => (Int.MinValue.toDouble, Int.MaxValue.toDouble)
-            case _          => (Double.MinValue, Double.MaxValue)
-          }
+          val (prim, min, max) =
+            s match {
+              case LongRange(min, max) =>
+                (PLong, min.map(BigDecimal(_)), max.map(BigDecimal(_)))
 
-          val max = Option(s.getMaximum())
-            .map(_.doubleValue())
-            .map(_.min(typedMax))
-            .map(BigDecimal(_))
+              case IntRange(min, max) =>
+                (PInt, min.map(BigDecimal(_)), max.map(BigDecimal(_)))
 
-          val min = Option(s.getMinimum())
-            .map(_.doubleValue())
-            .map(_.max(typedMin))
-            .map(BigDecimal(_))
+              case DoubleRange(min, max) =>
+                (PDouble, min.map(BigDecimal(_)), max.map(BigDecimal(_)))
+
+              case _ if s.requiresInteger() => (PInt, None, None) 
+              case _ if !s.requiresInteger() => (PDouble, None, None)
+            }
 
           val range =
             if (max.nonEmpty || min.nonEmpty) Some(Hint.Range(min, max))
             else None
+
           val hints: List[Hint] = List(desc, range).flatten
 
-          prim.map(hints -> _)
+          Some(hints -> prim)
 
         // S:
         //  type: string
@@ -438,6 +436,62 @@ private[json_schema] object Extractors {
 
   object int {
     def unapply(str: String): Option[Int] = str.toIntOption
+  }
+
+  object LongRange {
+    def unapply(sch: Schema): Option[(Option[Long], Option[Long])] = sch match {
+      case s: NumberSchema if s.isRequiresNumber() =>
+        val min = Option(s.getMinimum())
+        val max = Option(s.getMaximum())
+        (min, max) match {
+          case (Some(LongNumber(l)), _) =>
+            Some((Some(l), max.map(_.longValue())))
+          case (_, Some(LongNumber(l))) =>
+            Some((min.map(_.longValue()), Some(l)))
+          case _ => None
+        }
+      case _ => None
+    }
+  }
+
+  object IntRange {
+    def unapply(sch: Schema): Option[(Option[Int], Option[Int])] = sch match {
+      case s: NumberSchema if s.isRequiresNumber() =>
+        val min = Option(s.getMinimum())
+        val max = Option(s.getMaximum())
+        (min, max) match {
+          case (Some(IntNumber(mn)), None) => Some((Some(mn), None))
+          case (None, Some(IntNumber(mx))) => Some((None, Some(mx)))
+          case (Some(IntNumber(mn)), Some(IntNumber(mx))) =>
+            Some((Some(mn), Some(mx)))
+          case _ => None
+        }
+      case _ => None
+    }
+  }
+
+  object DoubleRange {
+    def unapply(sch: Schema): Option[(Option[Double], Option[Double])] =
+      sch match {
+        case s: NumberSchema if !s.isRequiresNumber() =>
+          val min = Option(s.getMinimum())
+          val max = Option(s.getMaximum())
+          Some((min.map(_.doubleValue()), max.map(_.doubleValue())))
+        case _ => None
+      }
+  }
+
+  object LongNumber {
+    def unapply(number: Number): Option[Long] =
+      Option(number.longValue())
+        .filter(x => x > Int.MaxValue || x < Int.MinValue)
+  }
+
+  object IntNumber {
+    def unapply(a: Number): Option[Int] =
+      Option(a.longValue())
+        .filter(x => x < Int.MaxValue && x > Int.MinValue)
+        .map(_.toInt)
   }
 
 }

--- a/modules/json-schema/src/internals/Extractors.scala
+++ b/modules/json-schema/src/internals/Extractors.scala
@@ -440,7 +440,7 @@ private[json_schema] object Extractors {
 
   object LongRange {
     def unapply(sch: Schema): Option[(Option[Long], Option[Long])] = sch match {
-      case s: NumberSchema if s.isRequiresNumber() =>
+      case s: NumberSchema if s.requiresInteger() =>
         val min = Option(s.getMinimum())
         val max = Option(s.getMaximum())
         (min, max) match {

--- a/modules/json-schema/test/src/ConstraintSpec.scala
+++ b/modules/json-schema/test/src/ConstraintSpec.scala
@@ -17,7 +17,7 @@ package smithytranslate.compiler.json_schema
 
 final class ConstraintSpec extends munit.FunSuite {
 
-  test("min max : integer") {
+  test("min max : int with long bounds") {
     val jsonSchString =
       """|{
          |  "$id": "test.json",
@@ -38,10 +38,103 @@ final class ConstraintSpec extends munit.FunSuite {
                             |
                             |structure Test {
                             |  @range(
-                            |    min: -2147483648,
-                            |    max: 2147483647
+                            |    min: -9223372036854775808,
+                            |    max: 9223372036854775807
+                            |  )
+                            |  number: Long
+                            |}
+                            |""".stripMargin
+
+    TestUtils.runConversionTest(jsonSchString, expectedString)
+  }
+
+  test("min max : integer with small whole-number bounds") {
+    val jsonSchString =
+      """|{
+         |  "$id": "test.json",
+         |  "$schema": "http://json-schema.org/draft-07/schema#",
+         |  "title": "Test",
+         |  "type": "object",
+         |  "properties": {
+         |    "number": {
+         |      "type": "integer",
+         |      "minimum": 1,
+         |      "maximum": 10
+         |    }
+         |  }
+         |}
+         |""".stripMargin
+
+    val expectedString = """|namespace foo
+                            |
+                            |structure Test {
+                            |  @range(
+                            |    min: 1,
+                            |    max: 10
                             |  )
                             |  number: Integer
+                            |}
+                            |""".stripMargin
+
+    TestUtils.runConversionTest(jsonSchString, expectedString)
+  }
+
+  test("min max : long with big max and small min bounds") {
+    val jsonSchString =
+      """|{
+         |  "$id": "test.json",
+         |  "$schema": "http://json-schema.org/draft-07/schema#",
+         |  "title": "Test",
+         |  "type": "object",
+         |  "properties": {
+         |    "number": {
+         |      "type": "integer",
+         |      "minimum": 1,
+         |      "maximum": 9223372036854775807
+         |    }
+         |  }
+         |}
+         |""".stripMargin
+
+    val expectedString = """|namespace foo
+                            |
+                            |structure Test {
+                            |  @range(
+                            |    min: 1,
+                            |    max: 9223372036854775807
+                            |  )
+                            |  number: Long
+                            |}
+                            |""".stripMargin
+
+    TestUtils.runConversionTest(jsonSchString, expectedString)
+  }
+
+  test("min max : long with small max and big min bounds") {
+    val jsonSchString =
+      """|{
+         |  "$id": "test.json",
+         |  "$schema": "http://json-schema.org/draft-07/schema#",
+         |  "title": "Test",
+         |  "type": "object",
+         |  "properties": {
+         |    "number": {
+         |      "type": "integer",
+         |      "minimum": -9223372036854775808,
+         |      "maximum": 1
+         |    }
+         |  }
+         |}
+         |""".stripMargin
+
+    val expectedString = """|namespace foo
+                            |
+                            |structure Test {
+                            |  @range(
+                            |    min: -9223372036854775808,
+                            |    max: 1
+                            |  )
+                            |  number: Long
                             |}
                             |""".stripMargin
 

--- a/modules/json-schema/test/src/ConstraintSpec.scala
+++ b/modules/json-schema/test/src/ConstraintSpec.scala
@@ -141,4 +141,33 @@ final class ConstraintSpec extends munit.FunSuite {
     TestUtils.runConversionTest(jsonSchString, expectedString)
   }
 
+  test("min max : double when number and some arbitrary range") {
+    val jsonSchString =
+      """|{
+         |  "$id": "test.json",
+         |  "$schema": "http://json-schema.org/draft-07/schema#",
+         |  "title": "Test",
+         |  "type": "object",
+         |  "properties": {
+         |    "number": {
+         |      "type": "number",
+         |      "maximum": 1
+         |    }
+         |  }
+         |}
+         |""".stripMargin
+
+    val expectedString = """|namespace foo
+                            |
+                            |structure Test {
+                            |  @range(
+                            |    max: 1.0
+                            |  )
+                            |  number: Double
+                            |}
+                            |""".stripMargin
+
+    TestUtils.runConversionTest(jsonSchString, expectedString)
+  }
+
 }


### PR DESCRIPTION
These changes fix a bug that would cause smithy to render ranges on integer types as non-whole numbers, which breaks model assembly.   

In the process I also introduced a check for constraints outside of the integer range to infer a long type.   Happy to remove that piece if desired.  Though it is a little surprising to see 64-bit doubles for non-whole numbers, and then 32bit ints by default for whole numbers with no way to support longs via json schema.

The means I use to detect what type of range constraint/number is appropriate is a bit verbose, leaning on unapply methods heavily, but I think the way that they're used makes the code fairly clear.  I can refactor it to a more compact solution if desired.